### PR TITLE
Implement aggregator tool run_pipeline invocation

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -321,6 +321,16 @@ def main() -> None:
         asyncio.run(telegram_bot_mode(cfg, Path(args.sources), Path(args.channels)))
     else:
 
+        out_dir = asyncio.run(
+            run_pipeline(
+                cfg,
+                protocols,
+                Path(args.sources),
+                Path(args.channels),
+            )
+        )
+        print(f"Aggregation complete. Files written to {out_dir.resolve()}")
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- wire up aggregator_tool to run the pipeline when not in bot mode
- print the final output directory on success

## Testing
- `python -m py_compile aggregator_tool.py`
- `pip install -r requirements.txt`
- `python aggregator_tool.py --sources /tmp/empty_sources --channels /tmp/empty_channels --output-dir /tmp/out` *(fails: ConnectionError: Connection to Telegram failed 5 time(s))*

------
https://chatgpt.com/codex/tasks/task_e_6870ae1a62048326adbe6eb7291eb95f