### PR TITLE
Add trojan & ssr support

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ Each server link is classified into a protocol type. By default the merger only 
 
 - **Proxy** (HTTP/SOCKS)
 - **Shadowsocks**
+- **ShadowsocksR**
+- **Trojan**
 - **Clash** / **ClashMeta**
 - **V2Ray** / **Xray**
 - **Reality**

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -127,7 +127,8 @@ CONFIG = Config(
     max_configs_per_source=75000,
     valid_prefixes=(
         "vmess://", "vless://", "reality://",
-        "ss://", "hy2://", "hysteria://", "hysteria2://",
+        "ss://", "ssr://", "trojan://",
+        "hy2://", "hysteria://", "hysteria2://",
         "tuic://", "shadowtls://", "wireguard://",
         "socks://", "socks4://", "socks5://",
         "http://", "https://", "grpc://", "ws://", "wss://",
@@ -142,7 +143,8 @@ CONFIG = Config(
     top_n=0,
     tls_fragment=None,
     include_protocols={
-        "PROXY", "SHADOWSOCKS", "CLASH", "V2RAY", "REALITY",
+        "PROXY", "SHADOWSOCKS", "SHADOWSOCKSR", "TROJAN",
+        "CLASH", "V2RAY", "REALITY",
         "VMESS", "XRAY", "WIREGUARD", "ECH", "VLESS",
         "HYSTERIA", "TUIC", "SING-BOX", "SINGBOX",
         "SHADOWTLS", "CLASHMETA", "HYSTERIA2",
@@ -927,6 +929,7 @@ class EnhancedConfigProcessor:
             "vmess://": "VMess",
             "vless://": "VLESS", 
             "ss://": "Shadowsocks",
+            "ssr://": "ShadowsocksR",
             "trojan://": "Trojan",
             "hy2://": "Hysteria2",
             "hysteria2://": "Hysteria2",


### PR DESCRIPTION
## Summary
- handle `ssr://` and `trojan://` links
- allow new protocol names by default
- update docs

## Testing
- `python -m py_compile aggregator_tool.py vpn_merger.py vpn_retester.py`
- `python vpn_merger.py --help` *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_6870af7e484483268fd04c9d73a20e32