### PR TITLE
Fix aggregator base64 parsing

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -29,7 +29,8 @@ CONFIG_FILE = Path("config.json")
 SOURCES_FILE = Path("sources.txt")
 CHANNELS_FILE = Path("channels.txt")
 
-PROTOCOL_RE = re.compile(r"(vmess|vless|trojan|ssr?|hysteria2?|tuic)://\S+", re.IGNORECASE)
+# Match full config links for supported protocols
+PROTOCOL_RE = re.compile(r"(?:vmess|vless|trojan|ssr?|hysteria2?|tuic)://\S+", re.IGNORECASE)
 BASE64_RE = re.compile(r"^[A-Za-z0-9+/=]+$")
 HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 


### PR DESCRIPTION
## Summary
- ensure aggregator regex returns full config link
- adjust aggregator regex comment

## Testing
- `python -m py_compile aggregator_tool.py vpn_merger.py vpn_retester.py`
- `pip install -r requirements.txt`
- `python aggregator_tool.py --help`
- `python vpn_merger.py --help`
- `python vpn_retester.py --help`
- *(failure)* `python aggregator_tool.py --config config.json --sources sample_sources.txt --channels channels.txt`

------
https://chatgpt.com/codex/tasks/task_e_6870abf1a7248326a5f35006d9aa7a61