### PR TITLE
Add Reality protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ links.
   "telegram_api_hash": "YOUR_HASH",
   "telegram_bot_token": "BOT_TOKEN",
   "allowed_user_ids": [11111111],
-  "protocols": ["vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2", "tuic"],
+  "protocols": ["vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2", "reality", "tuic"],
   "exclude_patterns": [],
   "output_dir": "output",
   "log_dir": "logs"

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -30,7 +30,10 @@ SOURCES_FILE = Path("sources.txt")
 CHANNELS_FILE = Path("channels.txt")
 
 # Match full config links for supported protocols
-PROTOCOL_RE = re.compile(r"(?:vmess|vless|trojan|ssr?|hysteria2?|tuic)://\S+", re.IGNORECASE)
+PROTOCOL_RE = re.compile(
+    r"(?:vmess|vless|trojan|ssr?|hysteria2?|tuic|reality)://\S+",
+    re.IGNORECASE,
+)
 BASE64_RE = re.compile(r"^[A-Za-z0-9+/=]+$")
 HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "telegram_api_hash": "YOUR_API_HASH",
   "telegram_bot_token": "YOUR_BOT_TOKEN",
   "allowed_user_ids": [123456789],
-  "protocols": ["vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2", "tuic"],
+  "protocols": ["vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2", "reality", "tuic"],
   "exclude_patterns": [],
   "output_dir": "output",
   "log_dir": "logs"


### PR DESCRIPTION
## Summary
- include `reality` URLs in PROTOCOL_RE
- list `reality` among default protocols in config.json and README documentation

## Testing
- `python -m py_compile aggregator_tool.py vpn_merger.py vpn_retester.py`

------
https://chatgpt.com/codex/tasks/task_e_68712d5bc1448326b15cc562b7f13ef4