### PR TITLE
Handle vmess fragments during validation

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -49,6 +49,8 @@ def is_valid_config(link: str) -> bool:
         return False
     if link.startswith("vmess://"):
         b64 = link.split("://", 1)[1]
+        # remove notes or query parameters
+        b64 = re.split(r"[?#]", b64, 1)[0]
         # pad base64 string if needed
         padded = b64 + "=" * (-len(b64) % 4)
         try:

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -1,0 +1,13 @@
+import base64
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from aggregator_tool import is_valid_config
+
+def test_vmess_with_fragment_accepted():
+    data = {"v": "2", "ps": "test"}
+    b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
+    link = f"vmess://{b64}#note"
+    assert is_valid_config(link)


### PR DESCRIPTION
## Summary
- improve vmess validation by removing query/fragment before decoding
- add unit test verifying a vmess link with a fragment is accepted

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712e8ae0348326b70f41100a7c1382