### PR TITLE
Improve aggregator Config load handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,14 @@ links.
 }
 ```
 
+Required fields: `telegram_api_id`, `telegram_api_hash`, `telegram_bot_token`, `allowed_user_ids`.
+Optional fields use these defaults when omitted:
+- `protocols` – `[]`
+- `exclude_patterns` – `[]`
+- `output_dir` – `output`
+- `log_dir` – `logs`
+- `max_concurrent` – `20`
+
 - **protocols** – only links starting with these schemes are kept.
 - **exclude_patterns** – regular expressions to remove unwanted links.
 - **output_dir** – where merged files are created.

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -75,9 +75,22 @@ class Config:
 
     @classmethod
     def load(cls, path: Path) -> "Config":
-        with path.open("r") as f:
-            data = json.load(f)
-        data.setdefault("max_concurrent", 20)
+        try:
+            with path.open("r") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+        defaults = {
+            "protocols": [],
+            "exclude_patterns": [],
+            "output_dir": "output",
+            "log_dir": "logs",
+            "max_concurrent": 20,
+        }
+        for key, value in defaults.items():
+            data.setdefault(key, value)
+
         return cls(**data)
 
 

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1,0 +1,32 @@
+import json
+import os
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from aggregator_tool import Config
+
+
+def test_load_defaults(tmp_path):
+    cfg = {
+        "telegram_api_id": 1,
+        "telegram_api_hash": "hash",
+        "telegram_bot_token": "token",
+        "allowed_user_ids": [1]
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg))
+    loaded = Config.load(p)
+    assert loaded.output_dir == "output"
+    assert loaded.log_dir == "logs"
+    assert loaded.protocols == []
+    assert loaded.exclude_patterns == []
+    assert loaded.max_concurrent == 20
+
+
+def test_load_invalid_json(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text("{ invalid }")
+    with pytest.raises(ValueError):
+        Config.load(p)


### PR DESCRIPTION
## Summary
- add default handling and JSON errors to `Config.load`
- explain required vs optional fields in the readme
- test `Config.load`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68713107d52c8326ab54144837c13293