### PR TITLE
Add concurrent limit option for aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,9 +556,9 @@ Optional fields use these defaults when omitted:
 - **exclude_patterns** – regular expressions to remove unwanted links.
 - **output_dir** – where merged files are created.
 - **log_dir** – daily log files are written here.
-- **max_concurrent** – maximum simultaneous HTTP requests.
+- **max_concurrent** – maximum simultaneous HTTP requests (override with `--concurrent-limit`).
 
-The command line options `--config`, `--sources`, `--channels`, `--output-dir`, `--max-concurrent`
+The command line options `--config`, `--sources`, `--channels`, `--output-dir`, `--concurrent-limit`
 let you override these file locations when running the tool.
 
 ### Important Notes


### PR DESCRIPTION
## Summary
- add concurrency limit to `fetch_and_parse_configs` in `aggregator_tool.py`
- support `--concurrent-limit` CLI option and hide old `--max-concurrent`
- document option in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687140beade083268fa9ade7fd3b1313