### PR TITLE
Fix invalid URLs and clarify sources format

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,8 +506,9 @@ links.
    Place them in `config.json` together with your bot token and the Telegram user
    IDs that are allowed to interact with the bot.
 3. Edit `sources.txt` and `channels.txt` to include any extra subscription URLs
-   or channel names you wish to scrape. By default the aggregator recognizes
-   links starting with `vmess`, `vless`, `trojan`, `ss`, `ssr`, `hysteria`,
+   or channel names you wish to scrape. **Put one valid URL on each line of**
+   `sources.txt`. By default the aggregator recognizes links starting with
+   `vmess`, `vless`, `trojan`, `ss`, `ssr`, `hysteria`,
    `hysteria2`, `tuic`, `reality`, `naive`, `hy2` and `wireguard`.
 4. Run the tool:
    ```bash

--- a/sources.txt
+++ b/sources.txt
@@ -1,5 +1,3 @@
-https://raw.githubusercontent.com/soroushmirzaei/telegram-configs-collector/refs/heads/main/protocols/vless
-https://raw.githubusercontent.com/barry-far/V2ray-Configs/main/Splitted-By-Protocol/trojan.txt
 https://v2.alicivil.workers.dev/?list=&count=5000&shuffle=true&unique=false
 https://raw.githubusercontent.com/amirparsaxs/-BegzarVPN/refs/heads/main/Begzar_sub_text
 https://raw.githubusercontent.com/liketolivefree/kobabi/main/singbox.json
@@ -9,18 +7,10 @@ https://github.com/Epodonios/v2ray-configs/raw/main/Splitted-By-Protocol/vmess.t
 https://github.com/Epodonios/v2ray-configs/raw/main/Splitted-By-Protocol/ss.txt
 https://github.com/Epodonios/v2ray-configs/raw/main/Splitted-By-Protocol/ssr.txt
 https://github.com/Epodonios/v2ray-configs/raw/main/Splitted-By-Protocol/trojan.txt
-https://shz.al/~@FREE2CONFIG_T,H
 https://raw.githubusercontent.com/Mosifree/-FREE2CONFIG/refs/heads/main/T,H
-https://github.com/alirezaazarnoosh/LOG/releases/tag/VPN
 https://igdux.top/~48-@ShadowProxy66
 https://raw.githubusercontent.com/Mosifree/-FREE2CONFIG/refs/heads/main/Movaghat
 https://raw.githubusercontent.com/Mosifree/-FREE2CONFIG/refs/heads/main/Clash_Movaghat
 https://raw.githubusercontent.com/Created-By/Telegram-Eag1e_YT/main/%40Eag1e_YT
-https://shz.al/~MTN3-TELEGRAM-@FREEV2RNG
-https://igdux.top/~Tel---@FREE2V2RNG
 https://raw.githubusercontent.com/SoliSpirit/v2ray-configs/refs/heads/main/Countries/Germany.txt
 https://xship.top/v1/subscribe?starlink=6KxKJp_Lrv6V1_zFRrvHXi41
-https://raw.githubusercontent.com/yebekhe/TelegramV2rayCollector/main/sub/reality
-https://raw.githubusercontent.com/PlanAsli/configs-collector-v2ray/refs/heads/main/sub/protocols/vmess.txt
-https://raw.githubusercontent.com/PlanAsli/configs-collector-v2ray/refs/heads/main/sub/protocols/vless.txt
-https://github.com/PlanAsli/configs-collector-v2ray/tree/main/sub


### PR DESCRIPTION
## Summary
- clean up `sources.txt` by dropping unreachable or unusable links
- note in README that `sources.txt` must contain one valid URL per line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871424336088326ace9c92845819f08