### PR TITLE
Enable concurrent validation of sources

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -170,25 +170,34 @@ def parse_configs_from_text(text: str) -> Set[str]:
     return configs
 
 
-async def check_and_update_sources(path: Path) -> List[str]:
-    """Validate and deduplicate sources list."""
+async def check_and_update_sources(path: Path, max_concurrent: int = 20) -> List[str]:
+    """Validate and deduplicate sources list using concurrent checks."""
     if not path.exists():
         logging.warning("sources file not found: %s", path)
         return []
+
     with path.open() as f:
         sources = {line.strip() for line in f if line.strip()}
 
-    valid_sources: List[str] = []
-    async with aiohttp.ClientSession() as session:
-        for url in sorted(sources):
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def check_one(session: ClientSession, url: str) -> str | None:
+        async with semaphore:
             text = await fetch_text(session, url)
-            if not text:
-                logging.info("Removing dead source: %s", url)
-                continue
-            if not parse_configs_from_text(text):
-                logging.info("Removing empty source: %s", url)
-                continue
-            valid_sources.append(url)
+        if not text:
+            logging.info("Removing dead source: %s", url)
+            return None
+        if not parse_configs_from_text(text):
+            logging.info("Removing empty source: %s", url)
+            return None
+        return url
+
+    connector = aiohttp.TCPConnector(limit=max_concurrent)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [asyncio.create_task(check_one(session, u)) for u in sorted(sources)]
+        results = await asyncio.gather(*tasks)
+
+    valid_sources = [r for r in results if r]
 
     with path.open("w") as f:
         for url in valid_sources:
@@ -336,7 +345,7 @@ async def run_pipeline(cfg: Config, protocols: List[str] | None = None,
                        sources_file: Path = SOURCES_FILE,
                        channels_file: Path = CHANNELS_FILE) -> Path:
     """Full aggregation pipeline. Returns output directory."""
-    sources = await check_and_update_sources(sources_file)
+    sources = await check_and_update_sources(sources_file, cfg.max_concurrent)
     configs = await fetch_and_parse_configs(sources, cfg.max_concurrent)
     configs |= await scrape_telegram_configs(channels_file, 24, cfg)
 


### PR DESCRIPTION
## Summary
- use asynchronous concurrency when validating subscription sources
- pass concurrency limit into source validation step

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871456c1f8c83268381e4e247da38e4