### PR TITLE
Improve config parsing and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,8 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
    ```
 2. Obtain a Telegram **API ID** and **API Hash** from <https://my.telegram.org>.
    Place them in `config.json` together with your bot token and the Telegram user
-   IDs that are allowed to interact with the bot.
+   IDs that are allowed to interact with the bot. A starter template is provided
+   in `config.json.example`.
 3. Edit `sources.txt` and `channels.txt` to include any extra subscription URLs
    or channel names you wish to scrape. **Put one valid URL on each line of**
    `sources.txt`. By default the aggregator recognizes links starting with
@@ -527,7 +528,7 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
 
 ### Configuration
 
-`config.json` contains all runtime options:
+`config.json` contains all runtime options (see `config.json.example` for a complete template):
 
 ```json
 {

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -102,6 +102,8 @@ class Config:
         try:
             with path.open("r") as f:
                 data = json.load(f)
+        except FileNotFoundError as exc:
+            raise ValueError(f"Config file not found: {path}") from exc
         except json.JSONDecodeError as exc:
             raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
 
@@ -132,10 +134,7 @@ class Config:
         try:
             return cls(**data)
         except (KeyError, TypeError) as exc:
-            msg = (
-                "config.json missing required fields: "
-                + ", ".join(required)
-            )
+            msg = f"Invalid configuration values: {exc}"
             print(msg)
             raise ValueError(msg) from exc
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,14 @@
+{
+  "telegram_api_id": 123456,
+  "telegram_api_hash": "YOUR_HASH",
+  "telegram_bot_token": "BOT_TOKEN",
+  "allowed_user_ids": [11111111],
+  "protocols": [
+    "vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2",
+    "tuic", "reality", "naive", "hy2", "wireguard"
+  ],
+  "exclude_patterns": [],
+  "output_dir": "output",
+  "log_dir": "logs",
+  "max_concurrent": 20
+}

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -32,6 +32,12 @@ def test_load_invalid_json(tmp_path):
         Config.load(p)
 
 
+def test_file_not_found(tmp_path):
+    missing = tmp_path / "absent.json"
+    with pytest.raises(ValueError):
+        Config.load(missing)
+
+
 def test_missing_required_fields(tmp_path, capsys):
     p = tmp_path / "cfg.json"
     p.write_text("{}")


### PR DESCRIPTION
## Summary
- catch `FileNotFoundError` when loading config
- clarify invalid configuration errors
- document config example in README
- include `config.json.example`
- test config not found case

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687145aef004832695df21a684bae608