### PR TITLE
Support multiple links per line

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -174,9 +174,9 @@ def parse_configs_from_text(text: str) -> Set[str]:
     configs: Set[str] = set()
     for line in text.splitlines():
         line = line.strip()
-        match = PROTOCOL_RE.search(line)
-        if match:
-            configs.add(match.group(0))
+        matches = PROTOCOL_RE.findall(line)
+        if matches:
+            configs.update(matches)
             continue
         if BASE64_RE.match(line):
             try:

--- a/tests/test_parse_configs.py
+++ b/tests/test_parse_configs.py
@@ -1,0 +1,13 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import aggregator_tool
+
+
+def test_multiple_links_same_line():
+    text = "vmess://a vless://b"
+    result = aggregator_tool.parse_configs_from_text(text)
+    assert "vmess://a" in result
+    assert "vless://b" in result
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- extract all config links on a line in `parse_configs_from_text`
- add a unit test covering multiple links on one line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68714aceb3d08326802ccbdd10178d28