### PR TITLE
Improve final summary for zero configs

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -69,3 +69,21 @@ def test_deduplicate_config_results(monkeypatch):
     assert len(unique) == 2
     hashes = [merger.processor.create_semantic_hash(r.config) for r in unique]
     assert len(set(hashes)) == 2
+
+
+def test_print_final_summary_zero_configs(capsys):
+    """Ensure summary handles empty results gracefully."""
+    merger = UltimateVPNMerger()
+    stats = {
+        "protocol_stats": {},
+        "performance_stats": {},
+        "total_configs": 0,
+        "reachable_configs": 0,
+        "available_sources": 0,
+        "total_sources": 0,
+    }
+
+    merger._print_final_summary(0, 0.5, stats)
+    captured = capsys.readouterr().out
+    assert "Success rate: N/A" in captured
+    assert "Top protocol: N/A" in captured

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1729,14 +1729,22 @@ class UltimateVPNMerger:
         print(f"⏱️  Total processing time: {elapsed_time:.2f} seconds")
         print(f"📊 Final unique configs: {config_count:,}")
         print(f"🌐 Reachable configs: {stats['reachable_configs']:,}")
-        print(f"📈 Success rate: {stats['reachable_configs']/config_count*100:.1f}%")
+        if config_count:
+            success = f"{stats['reachable_configs']/config_count*100:.1f}%"
+        else:
+            success = "N/A"
+        print(f"📈 Success rate: {success}")
         print(f"🔗 Available sources: {stats['available_sources']}/{stats['total_sources']}")
-        print(f"⚡ Processing speed: {config_count/elapsed_time:.0f} configs/second")
+        speed = (config_count / elapsed_time) if elapsed_time else 0
+        print(f"⚡ Processing speed: {speed:.0f} configs/second")
         
         if CONFIG.enable_sorting and stats['reachable_configs'] > 0:
             print(f"🚀 Configs sorted by performance (fastest first)")
         
-        top_protocol = max(stats['protocol_stats'].items(), key=lambda x: x[1])[0]
+        if stats['protocol_stats']:
+            top_protocol = max(stats['protocol_stats'].items(), key=lambda x: x[1])[0]
+        else:
+            top_protocol = "N/A"
         print(f"🏆 Top protocol: {top_protocol}")
         print(f"📁 Output directory: ./{CONFIG.output_dir}/")
         print("\n🔗 Usage Instructions:")


### PR DESCRIPTION
## Summary
- avoid division-by-zero in `_print_final_summary`
- show 'N/A' success rate and top protocol when no configs processed
- test `_print_final_summary` zero-config scenario

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871815e44d083268c50c7b08fdbbd24