### PR TITLE
Add env var overrides for aggregator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,9 +519,10 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
    ```
 2. Obtain a Telegram **API ID** and **API Hash** from <https://my.telegram.org>.
    Create your own `config.json` (you can copy `config.json.example`) and add
-   them along with your bot token and the Telegram user IDs allowed to interact
-   with the bot, **or** set the environment variables `TELEGRAM_API_ID`,
-   `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN` instead.  The example file shows
+  them along with your bot token and the Telegram user IDs allowed to interact
+  with the bot, **or** set the environment variables `TELEGRAM_API_ID`,
+  `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN` instead.  These environment
+  variables override any values in your `config.json`.  The example file shows
    all available options.
 3. Edit `sources.txt` and `channels.txt` to include any extra subscription URLs
    or channel names you wish to scrape. **Each line of `sources.txt` should
@@ -547,7 +548,7 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
 
 ### Configuration
 
-`config.json` contains all runtime options (see `config.json.example` for a complete template).  The values `telegram_api_id`, `telegram_api_hash` and `telegram_bot_token` may also be supplied through the environment variables `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN` when they are not present in the file:
+`config.json` contains all runtime options (see `config.json.example` for a complete template).  The values `telegram_api_id`, `telegram_api_hash` and `telegram_bot_token` may also be supplied through the environment variables `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN`.  When set, these environment variables override any values in the file:
 
 ```json
 {
@@ -571,7 +572,7 @@ recognized—any unknown keys will cause an error. Missing required fields will
 also trigger a helpful message listing what is absent.
 
 Required fields: `telegram_api_id`, `telegram_api_hash`, `telegram_bot_token`, `allowed_user_ids`.
-If the telegram fields are omitted from the file they will be looked up from the corresponding environment variables.
+If the telegram fields are omitted from the file they will be looked up from the corresponding environment variables.  When present, environment variables take precedence over the file values.
 If any are missing you'll see an error like:
 
 ```text

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -118,19 +118,21 @@ class Config:
         if not isinstance(data, dict):
             raise ValueError(f"{path} must contain a JSON object")
 
-        # Pull telegram credentials from environment when not present
+        # Pull telegram credentials from environment and override when set
         env_values = {
             "telegram_api_id": os.getenv("TELEGRAM_API_ID"),
             "telegram_api_hash": os.getenv("TELEGRAM_API_HASH"),
             "telegram_bot_token": os.getenv("TELEGRAM_BOT_TOKEN"),
         }
-        if "telegram_api_id" not in data and env_values["telegram_api_id"]:
+
+        if env_values["telegram_api_id"] is not None:
             try:
                 data["telegram_api_id"] = int(env_values["telegram_api_id"])
             except ValueError as exc:
                 raise ValueError("TELEGRAM_API_ID must be an integer") from exc
+
         for key in ("telegram_api_hash", "telegram_bot_token"):
-            if key not in data and env_values[key]:
+            if env_values[key] is not None:
                 data[key] = env_values[key]
 
         merged_defaults = {

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -70,3 +70,21 @@ def test_env_fallback(tmp_path, monkeypatch):
     assert loaded.telegram_api_id == 42
     assert loaded.telegram_api_hash == "hash"
     assert loaded.telegram_bot_token == "token"
+
+
+def test_env_override(tmp_path, monkeypatch):
+    cfg = {
+        "telegram_api_id": 1,
+        "telegram_api_hash": "hash",
+        "telegram_bot_token": "token",
+        "allowed_user_ids": [1],
+    }
+    p = tmp_path / "config.json"
+    p.write_text(json.dumps(cfg))
+    monkeypatch.setenv("TELEGRAM_API_ID", "99")
+    monkeypatch.setenv("TELEGRAM_API_HASH", "newhash")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "newtoken")
+    loaded = Config.load(p)
+    assert loaded.telegram_api_id == 99
+    assert loaded.telegram_api_hash == "newhash"
+    assert loaded.telegram_bot_token == "newtoken"


### PR DESCRIPTION
## Summary
- override config values with `TELEGRAM_*` env vars in `Config.load`
- mention env var override behaviour in README
- test environment variable overrides in `test_config_load`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718622981883269ab0ac41894a40c8