### PR TITLE
Add hours option for telegram lookback

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,9 +538,10 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
    The aggregated configuration links will be written to the folder specified in
    `output_dir` (default `output/`) as `merged.txt`, `merged_base64.txt` and
    `merged_singbox.json`.
-5. To enable the bot mode run:
+5. To enable the bot mode run (you can also pass `--hours` to control how much
+   channel history is scanned):
    ```bash
-   python aggregator_tool.py --bot
+   python aggregator_tool.py --bot --hours 12
    ```
    Send `/update` in your Telegram chat with the bot to trigger a run.  The bot
    will reply with the generated files.


### PR DESCRIPTION
## Summary
- allow specifying lookback hours in bot mode
- document using `--hours` with `--bot`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718605e060832680a8979c9bbe79d2