### PR TITLE
Remove automatic dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 
 > **Note**: The default protocol list is optimised for the Hiddify client. Other VPN apps may require adjusting `--include-protocols`.
 
+**Important**: Install the dependencies with `pip install -r requirements.txt` before running **any** of the Python scripts.
+
 ### ⚡ Quick Start
 
 1. Install **Python 3.8+** and clone this repository.

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -52,22 +52,19 @@ try:
     nest_asyncio.apply()
     if __name__ == "__main__":
         print("✅ Applied nest_asyncio patch for event loop compatibility")
-except ImportError:
-    if __name__ == "__main__":
-        print("📦 Installing nest_asyncio...")
-    import subprocess
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "nest-asyncio"])
-    import nest_asyncio
-    nest_asyncio.apply()
+except ImportError as exc:
+    raise ImportError(
+        "Missing optional dependency 'nest_asyncio'. "
+        "Run `pip install -r requirements.txt` before running this script."
+    ) from exc
 
 try:
     import aiodns
-except ImportError:
-    if __name__ == "__main__":
-        print("📦 Installing aiodns...")
-    import subprocess
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "aiodns"])
-    import aiodns
+except ImportError as exc:
+    raise ImportError(
+        "Missing optional dependency 'aiodns'. "
+        "Run `pip install -r requirements.txt` before running this script."
+    ) from exc
 
 # ============================================================================
 # CONFIGURATION & SETTINGS


### PR DESCRIPTION
## Summary
- remove auto-install logic from `vpn_merger.py`
- show an ImportError if `nest_asyncio` or `aiodns` is missing
- emphasise running `pip install -r requirements.txt` in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718814b21c8326a94c5d823b553f89