### PR TITLE
Fix case-insensitive exclusion

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -335,7 +335,7 @@ def deduplicate_and_filter(config_set: Set[str], cfg: Config, protocols: List[st
     """Apply filters and return sorted configs."""
     final = []
     protocols = protocols or cfg.protocols
-    exclude = [re.compile(p) for p in cfg.exclude_patterns]
+    exclude = [re.compile(p, re.IGNORECASE) for p in cfg.exclude_patterns]
     seen: Set[str] = set()
     for link in sorted(c.strip() for c in config_set):
         l_lower = link.lower()

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -23,3 +23,17 @@ def test_case_insensitive_deduplication():
     assert len(result) == 1
     assert result[0] in {lower, upper}
 
+
+def test_exclude_patterns_ignore_case():
+    link = "trojan://pw@foo.com:443"
+    cfg = aggregator_tool.Config(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=["trojan"],
+        exclude_patterns=["FOO"],
+    )
+    result = aggregator_tool.deduplicate_and_filter({link}, cfg)
+    assert result == []
+


### PR DESCRIPTION
## Summary
- handle user exclude patterns without case sensitivity
- test deduplicate_and_filter for case-insensitive excludes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871881062108326be1fc1975fbbdb1e