### PR TITLE
Clarify hours option

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
    starting with `vmess`, `vless`, `trojan`, `ss`,
    `ssr`, `hysteria`, `hysteria2`, `tuic`, `reality`, `naive`, `hy2` and
    `wireguard`.
-4. Run the tool (by default it scans the last 24 hours of channel history):
+4. Run the tool. The `--hours` option controls how many hours of channel history are scanned (default is 24):
    ```bash
    python aggregator_tool.py --hours 12
    ```

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -472,7 +472,7 @@ def main() -> None:
         "--hours",
         type=int,
         default=24,
-        help="how many hours of Telegram history to scan",
+        help="how many hours of Telegram history to scan (default %(default)s)",
     )
     parser.add_argument("--output-dir", help="override output directory from config")
     parser.add_argument(


### PR DESCRIPTION
## Summary
- document hours CLI default in README
- show the default in command-line help

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871880d678883268cc8c955edbfa33c