### PR TITLE
Add env var fallback for allowed user IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,10 +526,10 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
 2. Obtain a Telegram **API ID** and **API Hash** from <https://my.telegram.org>.
    Create your own `config.json` (you can copy `config.json.example`) and add
   them along with your bot token and the Telegram user IDs allowed to interact
-  with the bot, **or** set the environment variables `TELEGRAM_API_ID`,
-  `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN` instead.  These environment
-  variables override any values in your `config.json`.  The example file shows
-   all available options.
+  with the bot.  Alternatively set the environment variables `TELEGRAM_API_ID`,
+  `TELEGRAM_API_HASH`, `TELEGRAM_BOT_TOKEN` and `ALLOWED_USER_IDS`.
+  These variables override any values in your `config.json`.  The example file
+   shows all available options.
 3. Edit `sources.txt` and `channels.txt` to include any extra subscription URLs
    or channel names you wish to scrape. **Each line of `sources.txt` should
    contain exactly one valid URL with no extra text or spaces.** Each line of
@@ -555,7 +555,7 @@ and Trojan links must include an `@host:port`—and malformed entries are skippe
 
 ### Configuration
 
-`config.json` contains all runtime options (see `config.json.example` for a complete template).  The values `telegram_api_id`, `telegram_api_hash` and `telegram_bot_token` may also be supplied through the environment variables `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` and `TELEGRAM_BOT_TOKEN`.  When set, these environment variables override any values in the file:
+`config.json` contains all runtime options (see `config.json.example` for a complete template).  The values `telegram_api_id`, `telegram_api_hash`, `telegram_bot_token` and `allowed_user_ids` may also be supplied through the environment variables `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_BOT_TOKEN` and `ALLOWED_USER_IDS`.  When set, these environment variables override any values in the file:
 
 ```json
 {
@@ -579,7 +579,7 @@ recognized—any unknown keys will cause an error. Missing required fields will
 also trigger a helpful message listing what is absent.
 
 Required fields: `telegram_api_id`, `telegram_api_hash`, `telegram_bot_token`, `allowed_user_ids`.
-If the telegram fields are omitted from the file they will be looked up from the corresponding environment variables.  When present, environment variables take precedence over the file values.
+If any of these fields are omitted they will be looked up from the corresponding environment variables.  When present, environment variables take precedence over the file values.
 If any are missing you'll see an error like:
 
 ```text

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -123,6 +123,7 @@ class Config:
             "telegram_api_id": os.getenv("TELEGRAM_API_ID"),
             "telegram_api_hash": os.getenv("TELEGRAM_API_HASH"),
             "telegram_bot_token": os.getenv("TELEGRAM_BOT_TOKEN"),
+            "allowed_user_ids": os.getenv("ALLOWED_USER_IDS"),
         }
 
         if env_values["telegram_api_id"] is not None:
@@ -134,6 +135,19 @@ class Config:
         for key in ("telegram_api_hash", "telegram_bot_token"):
             if env_values[key] is not None:
                 data[key] = env_values[key]
+
+        if env_values["allowed_user_ids"] is not None:
+            try:
+                ids = [
+                    int(i)
+                    for i in re.split(r"[ ,]+", env_values["allowed_user_ids"].strip())
+                    if i
+                ]
+            except ValueError as exc:
+                raise ValueError(
+                    "ALLOWED_USER_IDS must be a comma separated list of integers"
+                ) from exc
+            data["allowed_user_ids"] = ids
 
         merged_defaults = {
             "protocols": [],

--- a/config.json.example
+++ b/config.json.example
@@ -1,3 +1,5 @@
+# You can set TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_BOT_TOKEN and
+# ALLOWED_USER_IDS in the environment and omit them from this file.
 {
   "telegram_api_id": 123456,
   "telegram_api_hash": "YOUR_HASH",

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -88,3 +88,30 @@ def test_env_override(tmp_path, monkeypatch):
     assert loaded.telegram_api_id == 99
     assert loaded.telegram_api_hash == "newhash"
     assert loaded.telegram_bot_token == "newtoken"
+
+
+def test_allowed_ids_env_fallback(tmp_path, monkeypatch):
+    cfg = {
+        "telegram_api_id": 1,
+        "telegram_api_hash": "hash",
+        "telegram_bot_token": "token",
+    }
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps(cfg))
+    monkeypatch.setenv("ALLOWED_USER_IDS", "5,6")
+    loaded = Config.load(p)
+    assert loaded.allowed_user_ids == [5, 6]
+
+
+def test_allowed_ids_env_override(tmp_path, monkeypatch):
+    cfg = {
+        "telegram_api_id": 1,
+        "telegram_api_hash": "hash",
+        "telegram_bot_token": "token",
+        "allowed_user_ids": [1],
+    }
+    p = tmp_path / "c.json"
+    p.write_text(json.dumps(cfg))
+    monkeypatch.setenv("ALLOWED_USER_IDS", "2 3")
+    loaded = Config.load(p)
+    assert loaded.allowed_user_ids == [2, 3]


### PR DESCRIPTION
## Summary
- support `ALLOWED_USER_IDS` environment variable in `Config.load`
- document env variable usage in README and example config
- add tests for `ALLOWED_USER_IDS`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6871881dc2f08326a8fd957fa5c8483f