### PR TITLE
Support no protocol filter by default

### DIFF
--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -37,3 +37,19 @@ def test_exclude_patterns_ignore_case():
     result = aggregator_tool.deduplicate_and_filter({link}, cfg)
     assert result == []
 
+
+def test_empty_protocol_list_accepts_all():
+    data = {"v": "2"}
+    b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
+    vmess = f"vmess://{b64}"
+    trojan = "trojan://pw@foo.com:443"
+    cfg = aggregator_tool.Config(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=[],
+    )
+    result = aggregator_tool.deduplicate_and_filter({vmess, trojan}, cfg)
+    assert set(result) == {vmess, trojan}
+


### PR DESCRIPTION
## Summary
- allow `deduplicate_and_filter` to skip protocol filtering when the final protocol list is empty
- add regression test for the default behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718ae924f48326b4377728efac9902