### PR TITLE
Remove auto-install logic and clarify requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+# Core runtime dependencies
 aiohttp
 aiodns
 nest-asyncio
+
+# Optional/feature dependencies
 telethon
 pytest
 PyYAML

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -43,8 +43,14 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
-import aiohttp
-from aiohttp.resolver import AsyncResolver
+try:
+    import aiohttp
+    from aiohttp.resolver import AsyncResolver
+except ImportError as exc:
+    raise ImportError(
+        "Missing optional dependency 'aiohttp'. "
+        "Run `pip install -r requirements.txt` before running this script."
+    ) from exc
 
 # Event loop compatibility fix
 try:


### PR DESCRIPTION
## Summary
- handle missing `aiohttp` import gracefully
- comment the dependency groups in `requirements.txt`

## Testing
- `pip install PyYAML`
- `pip install aiohttp aiodns nest-asyncio`
- `pip install telethon`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718ae3f87483269dd2a257c587e214