### PR TITLE
Add auto-merge GitHub workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,33 @@
+name: Merge VPN Subscriptions
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run vpn_merger.py
+        run: python vpn_merger.py
+      - name: Commit output files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add output
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Update merged VPN configs" && git push
+          fi

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This is the best method. You will create a personal copy (a "fork") of this repo
 
 **Step 3: Run the Workflow for the First Time**
 
-1.  In the left sidebar, click on the workflow named **`Merge VPN Subscriptions`**.
+1.  In the left sidebar, click on the workflow named **`Merge VPN Subscriptions`** (defined in `.github/workflows/merge.yml`).
 2.  You will see a blue banner that says "This workflow has a `workflow_dispatch` event trigger." Look to the right side of the screen and click the **`Run workflow`** dropdown button.
 3.  Leave the settings as they are and click the final green **`Run workflow`** button.
 4.  The script will now start running on GitHub's servers. Wait about 3-5 minutes for it to complete. You can click on the run to see its progress.
@@ -188,6 +188,8 @@ This is the best method. You will create a personal copy (a "fork") of this repo
 4.  On the file view page, click the **`Raw`** button.
 5.  **This is your link\!** The URL in your browser's address bar is your permanent, auto-updating subscription link. Copy it. It will look like this:
     `https://raw.githubusercontent.com/YOUR_USERNAME/CleanConfigs-SubMerger/main/output/vpn_subscription_base64.txt`
+
+This workflow runs automatically every day and commits the latest results to the `output/` folder so your link stays updated.
 
 You are now ready to use this link in any VPN app\!
 


### PR DESCRIPTION
## Summary
- create workflow to run `vpn_merger.py` on a daily schedule and push files in `output/`
- document the workflow in the GitHub Actions section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687195b4847c83268474f651732441d6