### PR TITLE
Add CLI flags to skip optional aggregator outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,15 +559,17 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
    starting with `vmess`, `vless`, `trojan`, `ss`,
    `ssr`, `hysteria`, `hysteria2`, `tuic`, `reality`, `naive`, `hy2` and
    `wireguard`.
-4. Run the tool. The `--hours` option controls how many hours of channel history are scanned (default is 24):
+4. Run the tool. The `--hours` option controls how many hours of channel history
+   are scanned (default is 24). Use `--no-base64`, `--no-singbox` or
+   `--no-clash` to skip optional outputs:
    ```bash
    python aggregator_tool.py --hours 12
    ```
    The aggregated configuration links will be written to the folder specified in
    `output_dir` (default `output/`) as `merged.txt`. Depending on the
-   `write_base64`, `write_singbox` and `write_clash` options the files
-   `merged_base64.txt`, `merged_singbox.json` and `clash.yaml` may also be
-   created.
+   `write_base64`, `write_singbox` and `write_clash` options—overridable with the
+   flags above—the files `merged_base64.txt`, `merged_singbox.json` and
+   `clash.yaml` may also be created.
 5. To enable the bot mode run (you can also pass `--hours` to control how much
    channel history is scanned):
    ```bash
@@ -623,8 +625,10 @@ Optional fields use these defaults when omitted:
 - **write_singbox** – create `merged_singbox.json` when `true`.
 - **write_clash** – create `clash.yaml` when `true`.
 
-The command line options `--config`, `--sources`, `--channels`, `--output-dir`, `--concurrent-limit`, `--hours`
-let you override these file locations when running the tool.
+The command line options `--config`, `--sources`, `--channels`, `--output-dir`,
+`--concurrent-limit`, `--hours`, `--no-base64`, `--no-singbox` and `--no-clash`
+let you override file locations or disable specific outputs when running the
+tool.
 
 ### Important Notes
 

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -664,6 +664,9 @@ def main() -> None:
         type=int,
         help=argparse.SUPPRESS,
     )
+    parser.add_argument("--no-base64", action="store_true", help="skip merged_base64.txt")
+    parser.add_argument("--no-singbox", action="store_true", help="skip merged_singbox.json")
+    parser.add_argument("--no-clash", action="store_true", help="skip clash.yaml")
     args = parser.parse_args()
 
     cfg = Config.load(Path(args.config))
@@ -673,6 +676,13 @@ def main() -> None:
         cfg.max_concurrent = args.concurrent_limit
     elif args.max_concurrent is not None:
         cfg.max_concurrent = args.max_concurrent
+
+    if args.no_base64:
+        cfg.write_base64 = False
+    if args.no_singbox:
+        cfg.write_singbox = False
+    if args.no_clash:
+        cfg.write_clash = False
 
     allowed_base = _get_script_dir()
     resolved_output = Path(cfg.output_dir).expanduser().resolve()

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -1,0 +1,71 @@
+import os
+import sys
+import json
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import aggregator_tool
+
+
+def test_output_files_skip_base64(tmp_path):
+    cfg = aggregator_tool.Config(write_base64=False)
+    aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
+    assert (tmp_path / "merged.txt").exists()
+    assert not (tmp_path / "merged_base64.txt").exists()
+
+
+def test_output_files_skip_singbox(tmp_path):
+    cfg = aggregator_tool.Config(write_singbox=False)
+    aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
+    assert (tmp_path / "merged.txt").exists()
+    assert not (tmp_path / "merged_singbox.json").exists()
+
+
+def test_output_files_skip_clash(tmp_path):
+    cfg = aggregator_tool.Config(write_clash=False)
+    aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
+    assert (tmp_path / "merged.txt").exists()
+    assert not (tmp_path / "clash.yaml").exists()
+
+
+def test_cli_flags_override(monkeypatch, tmp_path):
+    cfg_data = {
+        "output_dir": str(tmp_path / "out"),
+        "log_dir": str(tmp_path / "logs"),
+        "write_base64": True,
+        "write_singbox": True,
+        "write_clash": True,
+    }
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(json.dumps(cfg_data))
+
+    recorded = {}
+
+    async def fake_run_pipeline(cfg, *a, **k):
+        recorded["cfg"] = cfg
+        aggregator_tool.output_files(["vmess://a"], Path(cfg.output_dir), cfg)
+        return Path(cfg.output_dir), []
+
+    monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
+    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", [
+        "aggregator_tool.py",
+        "--config",
+        str(cfg_path),
+        "--no-base64",
+        "--no-singbox",
+        "--no-clash",
+    ])
+
+    aggregator_tool.main()
+
+    out_dir = Path(cfg_data["output_dir"])
+    assert (out_dir / "merged.txt").exists()
+    assert not (out_dir / "merged_base64.txt").exists()
+    assert not (out_dir / "merged_singbox.json").exists()
+    assert not (out_dir / "clash.yaml").exists()
+    cfg = recorded["cfg"]
+    assert not cfg.write_base64
+    assert not cfg.write_singbox
+    assert not cfg.write_clash


### PR DESCRIPTION
## Summary
- add `--no-base64`, `--no-singbox`, and `--no-clash` options to `aggregator_tool.py`
- allow these flags to override values loaded from `config.json`
- document the new flags in the Aggregator Tool section of the README
- add tests verifying file generation respects the flags and CLI values

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687198de8890832680a06a66425a1ac3