### PR TITLE
Add request timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,7 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
   "exclude_patterns": [],
   "output_dir": "output",
   "log_dir": "logs",
+  "request_timeout": 10,
   "max_concurrent": 20,
   "write_base64": true,
   "write_singbox": true,
@@ -647,6 +648,7 @@ Optional fields use these defaults when omitted:
 - `exclude_patterns` – `[]`
 - `output_dir` – `output`
 - `log_dir` – `logs`
+- `request_timeout` – `10`
 - `max_concurrent` – `20`
 - `write_base64` – `true`
 - `write_singbox` – `true`
@@ -656,15 +658,16 @@ Optional fields use these defaults when omitted:
 - **exclude_patterns** – regular expressions to remove unwanted links.
 - **output_dir** – where merged files are created.
 - **log_dir** – daily log files are written here.
+- **request_timeout** – HTTP request timeout in seconds (override with `--request-timeout`).
 - **max_concurrent** – maximum simultaneous HTTP requests for validating and fetching sources (override with `--concurrent-limit`).
 - **write_base64** – create `merged_base64.txt` when `true`.
 - **write_singbox** – create `merged_singbox.json` when `true`.
 - **write_clash** – create `clash.yaml` when `true`.
 
 The command line options `--config`, `--sources`, `--channels`, `--output-dir`,
-`--concurrent-limit`, `--hours`, `--no-base64`, `--no-singbox` and `--no-clash`
-let you override file locations or disable specific outputs when running the
-tool.
+`--concurrent-limit`, `--request-timeout`, `--hours`, `--no-base64`,
+`--no-singbox` and `--no-clash` let you override file locations or disable
+specific outputs when running the tool.
 
 ### Important Notes
 

--- a/config.json.example
+++ b/config.json.example
@@ -12,5 +12,6 @@
   "exclude_patterns": [],
   "output_dir": "output",
   "log_dir": "logs",
+  "request_timeout": 10,
   "max_concurrent": 20
 }

--- a/tests/test_check_sources.py
+++ b/tests/test_check_sources.py
@@ -11,7 +11,7 @@ def test_check_and_update_sources(monkeypatch, tmp_path):
     path = tmp_path / "sources.txt"
     path.write_text("good\nbad\n")
 
-    async def fake_fetch_text(session, url):
+    async def fake_fetch_text(session, url, timeout=10):
         if "good" in url:
             return "vmess://test"
         return None

--- a/tests/test_scrape_telegram_configs.py
+++ b/tests/test_scrape_telegram_configs.py
@@ -34,7 +34,7 @@ class DummyClient:
         pass
 
 
-async def fake_fetch_text(session, url):
+async def fake_fetch_text(session, url, timeout=10):
     if "sub.example" in url:
         return "vmess://from_url"
     return None


### PR DESCRIPTION
## Summary
- support setting `request_timeout` in aggregator `Config`
- use `request_timeout` when fetching URLs
- expose `--request-timeout` CLI option
- document new option and provide sample in `config.json.example`
- adjust tests for new function signatures

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687221cd332c832693e7025d6e559ba5