### PR TITLE
Handle SSR config links

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -74,6 +74,17 @@ def is_valid_config(link: str) -> bool:
             return True
         except Exception:
             return False
+    if scheme == "ssr":
+        padded = rest + "=" * (-len(rest) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(padded).decode()
+        except Exception:
+            return False
+        host_part = decoded.split("/", 1)[0]
+        if ":" not in host_part:
+            return False
+        host, port = host_part.split(":", 1)
+        return bool(host and port)
     host_required = {
         "naive",
         "hy2",
@@ -84,7 +95,6 @@ def is_valid_config(link: str) -> bool:
         "hysteria2",
         "tuic",
         "ss",
-        "ssr",
     }
     if scheme in host_required:
         if "@" not in rest:

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -36,3 +36,10 @@ def test_trojan_requires_host_port():
 def test_shadowsocks_requires_host_port():
     assert is_valid_config("ss://method:pw@example.com:8388")
     assert not is_valid_config("ss://method:pw@example.com")
+
+
+def test_ssr_base64_format():
+    raw = "example.com:443:origin:plain:password/"
+    b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
+    link = f"ssr://{b64}"
+    assert is_valid_config(link)


### PR DESCRIPTION
## Summary
- support decoding of SSR links in `is_valid_config`
- test SSR decoding logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687221e079188326b522962b67b0792a