### PR TITLE
Handle auth info in trojan and ss hashes

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -72,6 +72,22 @@ def test_deduplicate_config_results(monkeypatch):
     assert len(set(hashes)) == 2
 
 
+def test_trojan_password_affects_dedup(monkeypatch):
+    merger = UltimateVPNMerger()
+    monkeypatch.setattr(CONFIG, "tls_fragment", None)
+    monkeypatch.setattr(CONFIG, "include_protocols", None)
+    monkeypatch.setattr(CONFIG, "exclude_protocols", None)
+
+    link1 = make_trojan(passwd="pw1")
+    link2 = make_trojan(passwd="pw2")
+    r1 = ConfigResult(config=link1, protocol="Trojan")
+    r2 = ConfigResult(config=link2, protocol="Trojan")
+    unique = merger._deduplicate_config_results([r1, r2])
+    assert len(unique) == 2
+    hashes = [merger.processor.create_semantic_hash(r.config) for r in unique]
+    assert len(set(hashes)) == 2
+
+
 def test_print_final_summary_zero_configs(capsys):
     """Ensure summary handles empty results gracefully."""
     merger = UltimateVPNMerger()

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -279,6 +279,26 @@ class EnhancedConfigProcessor:
                     user_id = data.get("id") or data.get("uuid") or data.get("user")
             except Exception:
                 pass
+        elif config.startswith("trojan://"):
+            try:
+                parsed = urlparse(config)
+                user_part = parsed.username or parsed.password
+                if user_part:
+                    user_id = user_part
+            except Exception:
+                pass
+        elif config.startswith("ss://"):
+            try:
+                parsed = urlparse(config)
+                if parsed.username and parsed.password:
+                    user_id = f"{parsed.username}:{parsed.password}"
+                else:
+                    after = config.split("://", 1)[1].split("#", 1)[0]
+                    padded = after + "=" * (-len(after) % 4)
+                    decoded = base64.b64decode(padded).decode("utf-8", "ignore")
+                    user_id = decoded.split("@", 1)[0]
+            except Exception:
+                pass
 
         if host and port:
             key = f"{host}:{port}"


### PR DESCRIPTION
## Summary
- include user/pass information when creating semantic hashes for `trojan://` and `ss://` links
- add regression test ensuring Trojan links with different passwords remain distinct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872243dcf4c8326aac1839456ad87e7