### PR TITLE
Add SSR validation in is_valid_config

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -74,8 +74,12 @@ def is_valid_config(link: str) -> bool:
             return True
         except Exception:
             return False
-    if scheme == "ssr":
-        padded = rest + "=" * (-len(rest) % 4)
+
+    # ShadowsocksR links are base64 encoded after the scheme
+    if link.lower().startswith("ssr://"):
+        encoded = link[6:]
+        encoded = re.split(r"[?#]", encoded, 1)[0]
+        padded = encoded + "=" * (-len(encoded) % 4)
         try:
             decoded = base64.urlsafe_b64decode(padded).decode()
         except Exception:

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -43,3 +43,10 @@ def test_ssr_base64_format():
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}"
     assert is_valid_config(link)
+
+
+def test_ssr_with_fragment():
+    raw = "example.com:443:origin:plain:password/"
+    b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
+    link = f"ssr://{b64}#note"
+    assert is_valid_config(link)


### PR DESCRIPTION
## Summary
- handle `ssr://` scheme in `is_valid_config`
- add regression test confirming SSR links are valid

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687224401d4083269db4627294f71181