### PR TITLE
Improve naive Clash mapping

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -549,6 +549,7 @@ def output_files(configs: List[str], out_dir: Path, cfg: Config) -> List[Path]:
                     "port": p.port,
                     "username": p.username or "",
                     "password": p.password or "",
+                    "tls": True,
                 }
             else:
                 p = urlparse(config)

--- a/tests/test_aggregator_clash_proxy.py
+++ b/tests/test_aggregator_clash_proxy.py
@@ -1,0 +1,21 @@
+import os
+import sys
+import yaml
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import aggregator_tool
+
+
+def test_aggregator_clash_proxy(tmp_path):
+    cfg = aggregator_tool.Config(output_dir=str(tmp_path), write_clash=True)
+    configs = [
+        "reality://uuid@host:443?flow=xtls-rprx-vision",
+        "naive://user:pass@host:443",
+    ]
+    aggregator_tool.output_files(configs, tmp_path, cfg)
+    data = yaml.safe_load((tmp_path / "clash.yaml").read_text())
+    reality = next(p for p in data["proxies"] if p.get("flow"))
+    assert reality["type"] == "vless"
+    assert reality["tls"] is True
+    naive = next(p for p in data["proxies"] if p["type"] == "http")
+    assert naive["tls"] is True

--- a/tests/test_clash_proxies_yaml.py
+++ b/tests/test_clash_proxies_yaml.py
@@ -59,6 +59,7 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     naive = next(p for p in data["proxies"] if p["type"] == "http")
     assert naive["username"] == "user"
     assert naive["password"] == "pass"
+    assert naive["tls"] is True
     reality = next(p for p in data["proxies"] if p.get("flow"))
     assert reality["type"] == "vless"
     assert reality["tls"] is True

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1139,6 +1139,7 @@ class UltimateVPNMerger:
                     "port": p.port,
                     "username": p.username or "",
                     "password": p.password or "",
+                    "tls": True,
                 }
             else:
                 p = urlparse(config)


### PR DESCRIPTION
## Summary
- map naive links to Clash with `tls: true` in aggregator_tool
- map naive links to Clash with `tls: true` in vpn_merger
- update clash proxy tests for tls
- add regression test ensuring aggregator's Clash output handles Reality and Naive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872244881048326b2034ef7c73c0676