### PR TITLE
Sync aggregator protocol regex with merger

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -32,10 +32,12 @@ SOURCES_FILE = Path("sources.txt")
 CHANNELS_FILE = Path("channels.txt")
 
 # Match full config links for supported protocols
+# Additional schemes are kept roughly in the same order as ``vpn_merger`` to
+# ensure feature parity between the two modules.
 PROTOCOL_RE = re.compile(
     r"(?:"
-    r"vmess|vless|reality|ssr?|trojan|hy2|hysteria2?|tuic|"
-    r"shadowtls|juicity|naive|brook|wireguard|"
+    r"vmess|vless|reality|ssr?|trojan|hy2|hysteria2?|hysteria|tuic|"
+    r"shadowtls|brook|juicity|naive|wireguard|"
     r"socks5|socks4|socks|http|https|grpc|ws|wss|"
     r"tcp|kcp|quic|h2"
     r")://\S+",
@@ -94,12 +96,16 @@ def is_valid_config(link: str) -> bool:
         "hysteria",
         "hysteria2",
         "tuic",
+        "juicity",
         "ss",
     }
     if scheme in host_required:
         if "@" not in rest:
             return False
         host = rest.split("@", 1)[1].split("/", 1)[0]
+        return ":" in host
+    if scheme in {"shadowtls", "brook"}:
+        host = rest.split("@", 1)[-1].split("/", 1)[0]
         return ":" in host
     if scheme == "wireguard":
         return bool(rest)

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -43,3 +43,18 @@ def test_ssr_base64_format():
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}"
     assert is_valid_config(link)
+
+
+def test_shadowtls_requires_host_port():
+    assert is_valid_config("shadowtls://user@example.com:443")
+    assert not is_valid_config("shadowtls://user@example.com")
+
+
+def test_juicity_requires_host_port():
+    assert is_valid_config("juicity://token@example.com:443")
+    assert not is_valid_config("juicity://token@example.com")
+
+
+def test_brook_requires_host_port():
+    assert is_valid_config("brook://example.com:443")
+    assert not is_valid_config("brook://example.com")


### PR DESCRIPTION
## Summary
- expand `PROTOCOL_RE` to include schemes also supported in `vpn_merger`
- validate `shadowtls`, `juicity`, and `brook` configs
- add unit tests for these new protocols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225092b048326aa41b16ba99ba0be