### PR TITLE
Add SSR host/port extraction

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -38,6 +38,12 @@ def make_shadowsocks(password="pw", host="example.com", port=443, note=None, met
     return link
 
 
+def make_shadowsocksr(host="example.com", port=443):
+    raw = f"{host}:{port}:origin:plain:password/"
+    b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
+    return f"ssr://{b64}"
+
+
 def test_create_semantic_hash_consistent_with_fragment():
     proc = EnhancedConfigProcessor()
     link1 = make_trojan(note=None)
@@ -64,6 +70,14 @@ def test_create_semantic_hash_shadowsocks_password_difference():
     link1 = make_shadowsocks(password="one")
     link2 = make_shadowsocks(password="two")
     assert proc.create_semantic_hash(link1) != proc.create_semantic_hash(link2)
+
+
+def test_extract_host_port_ssr():
+    proc = EnhancedConfigProcessor()
+    link = make_shadowsocksr(host="h.example", port=1234)
+    host, port = proc.extract_host_port(link)
+    assert host == "h.example"
+    assert port == 1234
 
 
 def test_sort_by_performance():

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -246,6 +246,20 @@ class EnhancedConfigProcessor:
                     return host, int(port) if port else None
                 except Exception:
                     pass
+
+            if config.startswith("ssr://"):
+                try:
+                    after = config.split("://", 1)[1].split("#", 1)[0]
+                    padded = after + "=" * (-len(after) % 4)
+                    decoded = base64.urlsafe_b64decode(padded).decode()
+                    host_part = decoded.split("/", 1)[0]
+                    parts = host_part.split(":")
+                    if len(parts) < 2:
+                        return None, None
+                    host, port = parts[0], parts[1]
+                    return host or None, int(port)
+                except Exception:
+                    pass
             
             # Parse URI-style configs
             parsed = urlparse(config)
@@ -1150,6 +1164,23 @@ class UltimateVPNMerger:
                     "cipher": method,
                     "password": password,
                 }
+            elif scheme in ("ssr", "shadowsocksr"):
+                base = config.split("://", 1)[1].split("#", 1)[0]
+                try:
+                    padded = base + "=" * (-len(base) % 4)
+                    decoded = base64.urlsafe_b64decode(padded).decode()
+                    host_part = decoded.split("/", 1)[0]
+                    if ":" not in host_part:
+                        return None
+                    server, port = host_part.split(":", 1)
+                    return {
+                        "name": name,
+                        "type": "ssr",
+                        "server": server,
+                        "port": int(port),
+                    }
+                except Exception:
+                    return None
             elif scheme == "naive":
                 p = urlparse(config)
                 if not p.hostname or not p.port:


### PR DESCRIPTION
## Summary
- parse host and port from `ssr://` configs in `EnhancedConfigProcessor`
- handle SSR links when exporting Clash proxies
- add unit test ensuring SSR configs are parsed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872250f6c5c832691bfebaddf61a459