### PR TITLE
Improve trojan hash

### DIFF
--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -284,7 +284,15 @@ class EnhancedConfigProcessor:
         elif scheme == "trojan":
             try:
                 parsed = urlparse(config)
-                identifier = parsed.username or parsed.password
+                if parsed.username or parsed.password:
+                    identifier = parsed.username or ""
+                    if parsed.password is not None:
+                        if identifier:
+                            identifier += f":{parsed.password}"
+                        else:
+                            identifier = parsed.password
+                else:
+                    identifier = None
             except Exception:
                 pass
         elif scheme in ("ss", "shadowsocks"):


### PR DESCRIPTION
## Summary
- include username and password info in trojan semantic hash
- verify deduplication when trojan links contain userinfo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225ba72688326a4a2d71840db96cd