### PR TITLE
Improve SSR config validation

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -76,9 +76,8 @@ def is_valid_config(link: str) -> bool:
             return False
 
     # ShadowsocksR links are base64 encoded after the scheme
-    if link.lower().startswith("ssr://"):
-        encoded = link[6:]
-        encoded = re.split(r"[?#]", encoded, 1)[0]
+    if scheme == "ssr":
+        encoded = rest
         padded = encoded + "=" * (-len(encoded) % 4)
         try:
             decoded = base64.urlsafe_b64decode(padded).decode()

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -50,3 +50,10 @@ def test_ssr_with_fragment():
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}#note"
     assert is_valid_config(link)
+
+
+def test_ssr_basic_valid():
+    raw = "myhost.com:1234:origin:plain:pwd/"
+    b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
+    link = f"ssr://{b64}"
+    assert is_valid_config(link)


### PR DESCRIPTION
## Summary
- validate `ssr://` links in `is_valid_config`
- accept valid SSR config in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225bbafe08326b77ace32e9aa15c9