### PR TITLE
Implement failure tracking for source pruning

### DIFF
--- a/tests/test_check_sources.py
+++ b/tests/test_check_sources.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 import asyncio
+import json
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
@@ -18,5 +19,46 @@ def test_check_and_update_sources(monkeypatch, tmp_path):
 
     monkeypatch.setattr(aggregator_tool, "fetch_text", fake_fetch_text)
 
-    result = asyncio.run(aggregator_tool.check_and_update_sources(path, concurrent_limit=2))
+    result = asyncio.run(
+        aggregator_tool.check_and_update_sources(path, concurrent_limit=2)
+    )
     assert result == ["good"]
+    # bad should remain until failure threshold reached
+    lines = path.read_text().splitlines()
+    assert set(lines) == {"good", "bad"}
+    data = json.loads((tmp_path / "sources.failures.json").read_text())
+    assert data["bad"] == 1
+
+
+def test_prune_after_threshold(monkeypatch, tmp_path):
+    path = tmp_path / "sources.txt"
+    path.write_text("onlybad\n")
+
+    async def fail_fetch(session, url, timeout=10):
+        return None
+
+    monkeypatch.setattr(aggregator_tool, "fetch_text", fail_fetch)
+
+    # first run - not pruned
+    asyncio.run(
+        aggregator_tool.check_and_update_sources(
+            path,
+            concurrent_limit=1,
+            max_failures=2,
+            disabled_path=tmp_path / "disabled.txt",
+        )
+    )
+    assert path.read_text().splitlines() == ["onlybad"]
+
+    # second run - should be pruned
+    asyncio.run(
+        aggregator_tool.check_and_update_sources(
+            path,
+            concurrent_limit=1,
+            max_failures=2,
+            disabled_path=tmp_path / "disabled.txt",
+        )
+    )
+    assert path.read_text().strip() == ""
+    disabled = (tmp_path / "disabled.txt").read_text().strip().split()
+    assert "onlybad" in disabled[-1]

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -69,3 +69,28 @@ def test_cli_flags_override(monkeypatch, tmp_path):
     assert not cfg.write_base64
     assert not cfg.write_singbox
     assert not cfg.write_clash
+
+
+def test_cli_no_prune(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "c.json"
+    cfg_path.write_text(json.dumps({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
+
+    recorded = {}
+
+    async def fake_run_pipeline(cfg, *a, **k):
+        recorded.update(k)
+        return Path(), []
+
+    monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
+    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
+    monkeypatch.setattr(sys, "argv", [
+        "aggregator_tool.py",
+        "--config",
+        str(cfg_path),
+        "--no-prune",
+    ])
+
+    aggregator_tool.main()
+
+    assert recorded.get("prune") is False


### PR DESCRIPTION
## Summary
- add persistent failure counters for sources
- only remove links after a configurable number of failures
- introduce `--no-prune` CLI flag
- log pruned entries to `sources_disabled.txt`
- expand test coverage for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225c919d48326acc75c2f4b39d3c7