### PR TITLE
Centralize subscription sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [](https://opensource.org/licenses/MIT)
 
 Welcome to the VPN Subscription Merger! This project provides a powerful Python script that automatically fetches VPN configurations from the over 470 public sources listed in `sources.txt`, tests their connectivity, and merges them into a single, performance-sorted subscription link for use in your favorite VPN client. It can even save incremental batches while running so you always have up-to-date results.
+Both `aggregator_tool.py` and `vpn_merger.py` read from this same `sources.txt` file, so updating the list once applies to all tools.
 
 This guide is designed for **everyone**, from absolute beginners with no coding experience to advanced users who want full automation.
 
@@ -83,7 +84,7 @@ environment variable in `docker-compose.yml` to change how often it runs.
 
 | Feature | Description | Typical Use Case |
 | ------- | ----------- | ---------------- |
-| **Huge Source List** | `sources.txt` includes over 470 public subscription sources. | Get a massive selection of servers with a single command. |
+| **Huge Source List** | `sources.txt` includes over 470 public subscription sources and is shared by all tools. | Get a massive selection of servers with a single command. |
 | **Availability Testing** | Checks each source before downloading. | Skip dead links and save time. |
 | **Connectivity Testing** | Optional TCP checks measure real latency. | Prioritize servers that actually respond. |
 | **Smart Sorting** | Orders the final list by reachability and speed. | Quickly pick the best server in your VPN client. |

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -26,9 +26,9 @@ from aiohttp import ClientSession, ClientTimeout
 from telethon import TelegramClient, events, errors
 from telethon.tl.custom.message import Message
 
+from constants import SOURCES_FILE
 
 CONFIG_FILE = Path("config.json")
-SOURCES_FILE = Path("sources.txt")
 CHANNELS_FILE = Path("channels.txt")
 
 # Match full config links for supported protocols

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,4 @@
+from pathlib import Path
+
+SOURCES_FILE = Path("sources.txt")
+

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass, asdict, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
+
+from constants import SOURCES_FILE
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
 try:
@@ -187,7 +189,7 @@ EXCLUDE_REGEXES: List[re.Pattern] = []
 class UnifiedSources:
     """Load VPN subscription sources from an external file."""
 
-    DEFAULT_FILE = Path("sources.txt")
+    DEFAULT_FILE = SOURCES_FILE
     FALLBACK_SOURCES = [
         "https://raw.githubusercontent.com/barry-far/V2ray-config/main/Sub1.txt",
         "https://raw.githubusercontent.com/ssrsub/ssr/master/v2ray",


### PR DESCRIPTION
## Summary
- centralize the default sources file in `constants.py`
- have `aggregator_tool.py` and `vpn_merger.py` import the same constant
- document the shared `sources.txt` list in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687225c5e4c48326ac0e0487db7affd9