### PR TITLE
Fix cumulative batch counter

### DIFF
--- a/tests/test_maybe_save_batch.py
+++ b/tests/test_maybe_save_batch.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from vpn_merger import UltimateVPNMerger, ConfigResult, CONFIG
+
+
+def test_maybe_save_batch_strict_cumulative(monkeypatch, tmp_path):
+    monkeypatch.setattr(CONFIG, "batch_size", 1)
+    monkeypatch.setattr(CONFIG, "strict_batch", True)
+    monkeypatch.setattr(CONFIG, "cumulative_batches", True)
+    monkeypatch.setattr(CONFIG, "enable_sorting", False)
+    monkeypatch.setattr(CONFIG, "output_dir", str(tmp_path))
+
+    merger = UltimateVPNMerger()
+
+    async def dummy_generate(*_a, **_k):
+        pass
+
+    monkeypatch.setattr(UltimateVPNMerger, "_generate_comprehensive_outputs", dummy_generate)
+
+    result = ConfigResult(
+        config="vmess://a",
+        protocol="VMess",
+        host="host",
+        port=80,
+        ping_time=0.1,
+        is_reachable=True,
+        source_url="src",
+    )
+    merger.all_results.append(result)
+
+    asyncio.run(asyncio.wait_for(merger._maybe_save_batch(), 0.5))
+
+    assert merger.last_saved_count == len(merger.cumulative_unique)

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -818,6 +818,8 @@ class UltimateVPNMerger:
 
                 cumulative_stats = self._analyze_results(self.cumulative_unique, self.available_sources)
                 await self._generate_comprehensive_outputs(self.cumulative_unique, cumulative_stats, self.start_time, prefix="cumulative_")
+                if CONFIG.cumulative_batches:
+                    self.last_saved_count = len(self.cumulative_unique)
 
                 if CONFIG.threshold > 0 and len(self.cumulative_unique) >= CONFIG.threshold:
                     print(f"\n⏹️  Threshold of {CONFIG.threshold} configs reached. Stopping early.")
@@ -842,6 +844,8 @@ class UltimateVPNMerger:
 
                 cumulative_stats = self._analyze_results(self.cumulative_unique, self.available_sources)
                 await self._generate_comprehensive_outputs(self.cumulative_unique, cumulative_stats, self.start_time, prefix="cumulative_")
+                if CONFIG.cumulative_batches:
+                    self.last_saved_count = len(self.cumulative_unique)
 
                 self.next_batch_threshold += CONFIG.batch_size
 


### PR DESCRIPTION
## Summary
- update `last_saved_count` after each cumulative batch save
- add regression test to ensure `_maybe_save_batch` doesn't loop endlessly with strict+cum batches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728081bf048326a98c713a22e20915