### PR TITLE
Add with-merger flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,7 +634,7 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
 4. Run the tool. The `--hours` option controls how many hours of channel history
    are scanned (default is 24). Use `--no-base64`, `--no-singbox` or
    `--no-clash` to skip optional outputs. Add `--with-merger` to automatically
-   process the results with `vpn_merger.py`:
+   run `vpn_merger.py` on the generated `merged.txt` file:
    ```bash
    python aggregator_tool.py --hours 12
    ```
@@ -704,8 +704,8 @@ Optional fields use these defaults when omitted:
 The command line options `--config`, `--sources`, `--channels`, `--output-dir`,
 `--concurrent-limit`, `--request-timeout`, `--hours`, `--no-base64`,
 `--no-singbox`, `--no-clash` and `--with-merger` let you override file locations
-or disable specific outputs and optionally run the merger when the aggregation
-finishes.
+or disable specific outputs. When `--with-merger` is used the script invokes
+`vpn_merger.py` on `merged.txt` after the aggregation finishes.
 
 ### Important Notes
 

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -851,8 +851,8 @@ def main() -> None:
         print(f"Aggregation complete. Files written to {out_dir.resolve()}")
 
         if args.with_merger:
-            for path in files:
-                vpn_merger.detect_and_run(path)
+            if files:
+                vpn_merger.detect_and_run(files[0])
 
 
 

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -126,4 +126,4 @@ def test_cli_with_merger(monkeypatch, tmp_path):
 
     aggregator_tool.main()
 
-    assert called == files
+    assert called == [files[0]]


### PR DESCRIPTION
## Summary
- allow running `vpn_merger` from the aggregator with `--with-merger`
- document the new behaviour in the README
- adapt tests for changed behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872808b988083268d4111619846a172