### PR TITLE
Add country filtering options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 5. **Import your subscription**
    - Use the link in `output/vpn_subscription_base64.txt` (unless `--no-base64` was used) or load `vpn_singbox.json` in clients like sing-box.
 
-6. *(Optional)* pass extra flags like `--max-ping 200`, `--include-country US,CA` or `--concurrent-limit 10` to suit your connection.
+6. *(Optional)* pass extra flags like `--max-ping 200`, `--geoip-db GeoLite2-Country.mmdb --include-country US,CA` or `--concurrent-limit 10` to suit your connection.
 
 
 ## 🏁 Zero-to-Hero Walkthrough
@@ -191,7 +191,7 @@ environment variable in `docker-compose.yml` to change how often it runs.
 
 **Country Filtering**
 
-> Use `--include-country` or `--exclude-country` with a GeoIP database to limit servers to specific countries.
+> Use `--include-country` or `--exclude-country` together with `--geoip-db` to limit servers to specific countries.
 
 **Resume from File**
 
@@ -562,7 +562,7 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--smux N` - set smux stream count for protocols that support it (default `4`).
   * `--geoip-db PATH` - enable country lookup using a GeoLite2 database file.
   * `--include-country LIST` - comma-separated ISO codes to keep when `--geoip-db` is set.
-  * `--exclude-country LIST` - ISO codes to drop using the same lookup.
+  * `--exclude-country LIST` - ISO codes to drop when `--geoip-db` is set.
 
 TLS fragments help obscure the real Server Name Indication (SNI) of each
 connection by splitting the handshake into pieces. This makes it harder for

--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -230,3 +230,24 @@ def test_country_filters(monkeypatch):
     monkeypatch.setattr(CONFIG, "exclude_countries", {"FR"})
     unique = merger._deduplicate_config_results([r1, r2])
     assert {u.config for u in unique} == {"a"}
+
+
+def test_country_filters_no_geoip(monkeypatch):
+    """Configs should not be filtered when GeoIP info is missing."""
+    merger = UltimateVPNMerger()
+    monkeypatch.setattr(CONFIG, "tls_fragment", None)
+    monkeypatch.setattr(CONFIG, "include_protocols", None)
+    monkeypatch.setattr(CONFIG, "exclude_protocols", None)
+
+    r1 = ConfigResult(config="a", protocol="VMess", country=None)
+    r2 = ConfigResult(config="b", protocol="VMess", country=None)
+
+    monkeypatch.setattr(CONFIG, "include_countries", {"US"})
+    monkeypatch.setattr(CONFIG, "exclude_countries", None)
+    unique = merger._deduplicate_config_results([r1, r2])
+    assert {u.config for u in unique} == {"a", "b"}
+
+    monkeypatch.setattr(CONFIG, "include_countries", None)
+    monkeypatch.setattr(CONFIG, "exclude_countries", {"CN"})
+    unique = merger._deduplicate_config_results([r1, r2])
+    assert {u.config for u in unique} == {"a", "b"}

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -866,12 +866,12 @@ class UltimateVPNMerger:
                 continue
             if CONFIG.exclude_protocols and result.protocol.upper() in CONFIG.exclude_protocols:
                 continue
-            if CONFIG.include_countries and (
-                not result.country or result.country.upper() not in CONFIG.include_countries
-            ):
-                continue
-            if CONFIG.exclude_countries and result.country and result.country.upper() in CONFIG.exclude_countries:
-                continue
+            if CONFIG.include_countries and result.country:
+                if result.country.upper() not in CONFIG.include_countries:
+                    continue
+            if CONFIG.exclude_countries and result.country:
+                if result.country.upper() in CONFIG.exclude_countries:
+                    continue
             if EXCLUDE_REGEXES and any(r.search(text) for r in EXCLUDE_REGEXES):
                 continue
             config_hash = self.processor.create_semantic_hash(result.config)
@@ -1423,10 +1423,18 @@ def main():
                         help="Do not save simple Clash proxy list")
     parser.add_argument("--geoip-db", type=str, default=None,
                         help="Path to GeoLite2 Country database for GeoIP lookup")
-    parser.add_argument("--include-country", type=str, default=None,
-                        help="Comma-separated ISO codes to include (requires GeoIP)")
-    parser.add_argument("--exclude-country", type=str, default=None,
-                        help="Comma-separated ISO codes to exclude")
+    parser.add_argument(
+        "--include-country",
+        type=str,
+        default=None,
+        help="Comma-separated ISO codes to include when GeoIP is enabled",
+    )
+    parser.add_argument(
+        "--exclude-country",
+        type=str,
+        default=None,
+        help="Comma-separated ISO codes to exclude when GeoIP is enabled",
+    )
     args, unknown = parser.parse_known_args()
     if unknown:
         logging.warning("Ignoring unknown arguments: %s", unknown)


### PR DESCRIPTION
## Summary
- add country filter arguments to CLI help
- filter configs by country only when GeoIP data is available
- extend README with example GeoIP usage
- test country filtering when no GeoIP info

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687282a01dfc832695d90bed444e22ac