### PR TITLE
Fix protocol case handling

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -412,6 +412,8 @@ def deduplicate_and_filter(
     # ``protocols`` overrides ``cfg.protocols`` when provided, even if empty
     if protocols is None:
         protocols = cfg.protocols
+    if protocols:
+        protocols = [p.lower() for p in protocols]
     exclude = [re.compile(p, re.IGNORECASE) for p in cfg.exclude_patterns]
     seen: Set[str] = set()
     for link in sorted(c.strip() for c in config_set):
@@ -822,7 +824,7 @@ def main() -> None:
     cfg.log_dir = str(resolved_log_dir)
 
     if args.protocols:
-        protocols = [p.strip() for p in args.protocols.split(",") if p.strip()]
+        protocols = [p.strip().lower() for p in args.protocols.split(",") if p.strip()]
     else:
         protocols = None
 

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -52,3 +52,35 @@ def test_empty_protocol_list_accepts_all():
     )
     result = aggregator_tool.deduplicate_and_filter({vmess, trojan}, cfg)
     assert set(result) == {vmess, trojan}
+
+
+def test_protocol_filter_mixed_case_from_cfg():
+    data = {"v": "2"}
+    b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
+    vmess = f"vmess://{b64}"
+    trojan = "trojan://pw@foo.com:443"
+    cfg = aggregator_tool.Config(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=["TroJAN"],
+    )
+    result = aggregator_tool.deduplicate_and_filter({vmess, trojan}, cfg)
+    assert result == [trojan]
+
+
+def test_protocol_filter_mixed_case_argument():
+    data = {"v": "2"}
+    b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
+    vmess = f"vmess://{b64}"
+    trojan = "trojan://pw@foo.com:443"
+    cfg = aggregator_tool.Config(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=[],
+    )
+    result = aggregator_tool.deduplicate_and_filter({vmess, trojan}, cfg, ["VMeSS"])
+    assert result == [vmess]


### PR DESCRIPTION
## Summary
- normalize protocol arguments in CLI to lowercase
- normalize protocol lists in deduplicate_and_filter
- test mixed-case protocols in deduplication and CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687284458de4832689a3c456616b68d7