### PR TITLE
Remove print statement from Config.load

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -204,7 +204,6 @@ class Config:
             return cls(**data)
         except (KeyError, TypeError) as exc:
             msg = f"Invalid configuration values: {exc}"
-            print(msg)
             raise ValueError(msg) from exc
 
 


### PR DESCRIPTION
## Summary
- drop debugging print when Config.load raises ValueError

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d9c8c5e48326af4ebd5432167800