### PR TITLE
Update aggregator merger integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
    python aggregator_tool.py --with-merger
    ```
 
-   The merger automatically runs after aggregation finishes.
+   The merger automatically runs on the freshly aggregated results using the
+   resume feature.
 
 7. **Country filters**
 
@@ -687,7 +688,7 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
 4. Run the tool. The `--hours` option controls how many hours of channel history
    are scanned (default is 24). Use `--no-base64`, `--no-singbox` or
    `--no-clash` to skip optional outputs. Add `--with-merger` to automatically
-   run `vpn_merger.py` on the generated output directory:
+   run `vpn_merger.py` on the freshly aggregated configs via `--resume`:
    ```bash
    python aggregator_tool.py --hours 12
    ```
@@ -759,8 +760,9 @@ Optional fields use these defaults when omitted:
 The command line options `--config`, `--sources`, `--channels`, `--output-dir`,
 `--concurrent-limit`, `--request-timeout`, `--hours`, `--no-base64`,
 `--no-singbox`, `--no-clash` and `--with-merger` let you override file locations
-or disable specific outputs. When `--with-merger` is used the script invokes
-`vpn_merger.py` on the generated output directory after the aggregation finishes.
+or disable specific outputs. When `--with-merger` is used the script sets
+`vpn_merger`'s `resume_file` to `output_dir/merged.txt` and runs the merger on
+that file.
 
 ### Important Notes
 

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -800,7 +800,7 @@ def main() -> None:
     parser.add_argument(
         "--with-merger",
         action="store_true",
-        help="run vpn_merger on the generated output directory after aggregation",
+        help="run vpn_merger on the aggregated results using the resume feature",
     )
     args = parser.parse_args()
 
@@ -868,7 +868,8 @@ def main() -> None:
         print(f"Aggregation complete. Files written to {out_dir.resolve()}")
 
         if args.with_merger:
-            vpn_merger.detect_and_run(out_dir)
+            vpn_merger.CONFIG.resume_file = str(out_dir / "merged.txt")
+            vpn_merger.detect_and_run()
 
 
 

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -110,8 +110,8 @@ def test_cli_with_merger(monkeypatch, tmp_path):
 
     called = []
 
-    def fake_detect_and_run(path):
-        called.append(Path(path))
+    def fake_detect_and_run(*args):
+        called.append(args)
 
     monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
@@ -126,7 +126,8 @@ def test_cli_with_merger(monkeypatch, tmp_path):
 
     aggregator_tool.main()
 
-    assert called == [tmp_path / "o"]
+    assert called == [tuple()]
+    assert aggregator_tool.vpn_merger.CONFIG.resume_file == str(tmp_path / "o" / "merged.txt")
 
 
 def test_cli_protocols_case_insensitive(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- run vpn_merger via resume file when using `--with-merger`
- document that behaviour in README
- test that the resume file is set and detect_and_run is called without args

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872d9c278a483268b8c9ecd71796ccc