### PR TITLE
Fix allowed_user_ids type handling

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -178,6 +178,12 @@ class Config:
                 ) from exc
             data["allowed_user_ids"] = ids
 
+        if "allowed_user_ids" in data:
+            try:
+                data["allowed_user_ids"] = [int(i) for i in data["allowed_user_ids"]]
+            except Exception as exc:
+                raise ValueError("allowed_user_ids must be a list of integers") from exc
+
         merged_defaults = {
             "protocols": [],
             "exclude_patterns": [],

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -119,3 +119,16 @@ def test_allowed_ids_env_override(tmp_path, monkeypatch):
     monkeypatch.setenv("ALLOWED_USER_IDS", "2 3")
     loaded = Config.load(p)
     assert loaded.allowed_user_ids == [2, 3]
+
+
+def test_allowed_ids_string_values(tmp_path):
+    cfg = {
+        "telegram_api_id": 1,
+        "telegram_api_hash": "hash",
+        "telegram_bot_token": "token",
+        "allowed_user_ids": ["7", "8"],
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg))
+    loaded = Config.load(p)
+    assert loaded.allowed_user_ids == [7, 8]


### PR DESCRIPTION
## Summary
- ensure Config.load casts allowed_user_ids list values to int
- add test for loading config with string user IDs

## Testing
- `pytest -q`
- `flake8 .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6872da98b8c08326bccd03bcca0a0e0d