### PR TITLE
Add oversized base64 guard in aggregator

### DIFF
--- a/tests/test_parse_configs.py
+++ b/tests/test_parse_configs.py
@@ -37,3 +37,11 @@ def test_extract_all_protocols():
     assert len(result) == 15
     for item in text.split():
         assert item in result
+
+
+def test_parse_oversized_line(caplog):
+    big_line = "A" * (aggregator_tool.MAX_DECODE_SIZE + 1)
+    with caplog.at_level('DEBUG'):
+        result = aggregator_tool.parse_configs_from_text(big_line)
+    assert result == set()
+    assert "Skipping oversized base64 line" in caplog.text


### PR DESCRIPTION
## Summary
- prevent extremely long lines from being base64 decoded
- test oversized input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872daca5df88326b421dfdc0d11ab66