### PR TITLE
Narrow exception handling in VPN retester

### DIFF
--- a/tests/test_retester_load_configs.py
+++ b/tests/test_retester_load_configs.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import base64
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import vpn_retester
+
+
+def test_load_base64(tmp_path):
+    text = "vmess://a\nvless://b"
+    data = base64.b64encode(text.encode()).decode()
+    p = tmp_path / "subs.txt"
+    p.write_text(data, encoding="utf-8")
+    result = vpn_retester.load_configs(p)
+    assert result == ["vmess://a", "vless://b"]
+
+
+def test_load_base64_error(tmp_path):
+    p = tmp_path / "bad.txt"
+    p.write_text("a", encoding="utf-8")
+    with pytest.raises(ValueError):
+        vpn_retester.load_configs(p)
+
+
+def test_decode_other_error(tmp_path, monkeypatch):
+    p = tmp_path / "file.txt"
+    p.write_text("data", encoding="utf-8")
+
+    def boom(_):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(vpn_retester.base64, "b64decode", boom)
+    with pytest.raises(RuntimeError):
+        vpn_retester.load_configs(p)
+

--- a/vpn_retester.py
+++ b/vpn_retester.py
@@ -4,6 +4,7 @@
 import asyncio
 import argparse
 import base64
+import binascii
 import csv
 from pathlib import Path
 from typing import List, Tuple, Optional
@@ -37,7 +38,7 @@ def load_configs(path: Path) -> List[str]:
     if text and '://' not in text.splitlines()[0]:
         try:
             text = base64.b64decode(text).decode("utf-8")
-        except Exception as e:
+        except (binascii.Error, UnicodeDecodeError) as e:
             raise ValueError("Failed to decode base64 input") from e
     return [line.strip() for line in text.splitlines() if line.strip()]
 


### PR DESCRIPTION
## Summary
- handle only base64 decoding errors in `load_configs`
- test `load_configs` base64 behaviour and error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872dbc4e0888326b912f49912fe5ea8