### PR TITLE
Refactor Clash proxy logic

### DIFF
--- a/clash_utils.py
+++ b/clash_utils.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+from urllib.parse import parse_qs, urlparse
+from typing import Dict, Optional, Union
+
+
+def config_to_clash_proxy(
+    config: str,
+    idx: int = 0,
+    protocol: Optional[str] = None,
+) -> Optional[Dict[str, Union[str, int, bool]]]:
+    """Convert a single config link to a Clash proxy dictionary."""
+    try:
+        scheme = (protocol or config.split("://", 1)[0]).lower()
+        name = f"{scheme}-{idx}"
+        if scheme == "vmess":
+            after = config.split("://", 1)[1]
+            base = after.split("#", 1)[0]
+            try:
+                padded = base + "=" * (-len(base) % 4)
+                data = json.loads(base64.b64decode(padded).decode())
+                name = data.get("ps") or data.get("name") or name
+                proxy = {
+                    "name": name,
+                    "type": "vmess",
+                    "server": data.get("add") or data.get("host", ""),
+                    "port": int(data.get("port", 0)),
+                    "uuid": data.get("id") or data.get("uuid", ""),
+                    "alterId": int(data.get("aid", 0)),
+                    "cipher": data.get("type", "auto"),
+                }
+                if data.get("tls") or data.get("security"):
+                    proxy["tls"] = True
+                return proxy
+            except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+                logging.debug("Fallback Clash parse for vmess: %s", exc)
+                p = urlparse(config)
+                q = parse_qs(p.query)
+                proxy = {
+                    "name": p.fragment or name,
+                    "type": "vmess",
+                    "server": p.hostname or "",
+                    "port": p.port or 0,
+                    "uuid": p.username or "",
+                    "alterId": int(q.get("aid", [0])[0]),
+                    "cipher": q.get("type", ["auto"])[0],
+                }
+                if q.get("security"):
+                    proxy["tls"] = True
+                return proxy
+        elif scheme == "vless":
+            p = urlparse(config)
+            q = parse_qs(p.query)
+            proxy = {
+                "name": p.fragment or name,
+                "type": "vless",
+                "server": p.hostname or "",
+                "port": p.port or 0,
+                "uuid": p.username or "",
+                "encryption": q.get("encryption", ["none"])[0],
+            }
+            if q.get("security"):
+                proxy["tls"] = True
+            return proxy
+        elif scheme == "reality":
+            p = urlparse(config)
+            q = parse_qs(p.query)
+            proxy = {
+                "name": p.fragment or name,
+                "type": "vless",
+                "server": p.hostname or "",
+                "port": p.port or 0,
+                "uuid": p.username or "",
+                "encryption": q.get("encryption", ["none"])[0],
+                "tls": True,
+            }
+            flows = q.get("flow")
+            if flows:
+                proxy["flow"] = flows[0]
+            return proxy
+        elif scheme == "trojan":
+            p = urlparse(config)
+            q = parse_qs(p.query)
+            proxy = {
+                "name": p.fragment or name,
+                "type": "trojan",
+                "server": p.hostname or "",
+                "port": p.port or 0,
+                "password": p.username or p.password or "",
+            }
+            sni_vals = q.get("sni")
+            if sni_vals:
+                proxy["sni"] = sni_vals[0]
+            if q.get("security"):
+                proxy["tls"] = True
+            return proxy
+        elif scheme in ("ss", "shadowsocks"):
+            p = urlparse(config)
+            if p.username and p.password and p.hostname and p.port:
+                method = p.username
+                password = p.password
+                server = p.hostname
+                port = p.port
+            else:
+                base = config.split("://", 1)[1].split("#", 1)[0]
+                padded = base + "=" * (-len(base) % 4)
+                decoded = base64.b64decode(padded).decode()
+                before_at, host_port = decoded.split("@")
+                method, password = before_at.split(":")
+                server_str, port_str = host_port.split(":")
+                server = server_str
+                port = int(port_str)
+            return {
+                "name": p.fragment or name,
+                "type": "ss",
+                "server": server,
+                "port": int(port),
+                "cipher": method,
+                "password": password,
+            }
+        elif scheme in ("ssr", "shadowsocksr"):
+            base = config.split("://", 1)[1].split("#", 1)[0]
+            try:
+                padded = base + "=" * (-len(base) % 4)
+                decoded = base64.urlsafe_b64decode(padded).decode()
+                host_part = decoded.split("/", 1)[0]
+                if ":" not in host_part:
+                    return None
+                server_str, port_str = host_part.split(":", 1)
+                server = server_str
+                port = int(port_str)
+                return {
+                    "name": name,
+                    "type": "ssr",
+                    "server": server,
+                    "port": int(port),
+                }
+            except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
+                logging.debug("SSRs parse failed: %s", exc)
+                return None
+        elif scheme == "naive":
+            p = urlparse(config)
+            if not p.hostname or not p.port:
+                return None
+            return {
+                "name": p.fragment or name,
+                "type": "http",
+                "server": p.hostname,
+                "port": p.port,
+                "username": p.username or "",
+                "password": p.password or "",
+                "tls": True,
+            }
+        else:
+            p = urlparse(config)
+            if not p.hostname or not p.port:
+                return None
+            typ = "socks5" if scheme.startswith("socks") else "http"
+            return {
+                "name": p.fragment or name,
+                "type": typ,
+                "server": p.hostname,
+                "port": p.port,
+            }
+    except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        logging.debug("config_to_clash_proxy failed: %s", exc)
+        return None

--- a/tests/test_clash_utils_import.py
+++ b/tests/test_clash_utils_import.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from clash_utils import config_to_clash_proxy
+
+
+def test_config_to_clash_proxy_import():
+    proxy = config_to_clash_proxy("naive://user:pass@host:443", 0)
+    assert proxy["type"] == "http"
+    assert proxy["tls"] is True

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -45,6 +45,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 from constants import SOURCES_FILE
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from clash_utils import config_to_clash_proxy
 
 try:
     import aiohttp
@@ -1133,7 +1134,7 @@ class UltimateVPNMerger:
         if CONFIG.write_clash_proxies:
             proxies = []
             for idx, r in enumerate(results):
-                proxy = self._config_to_clash_proxy(r.config, r.protocol, idx)
+                proxy = config_to_clash_proxy(r.config, idx, r.protocol)
                 if proxy:
                     proxies.append(proxy)
             proxy_yaml = yaml.safe_dump({"proxies": proxies}, allow_unicode=True, sort_keys=False) if proxies else ""
@@ -1142,174 +1143,12 @@ class UltimateVPNMerger:
             tmp_proxies.write_text(proxy_yaml, encoding="utf-8")
             tmp_proxies.replace(proxies_file)
 
-    def _config_to_clash_proxy(
-        self,
-        config: str,
-        protocol: str,
-        idx: int,
-    ) -> Optional[Dict[str, Union[str, int, bool]]]:
-        """Convert a single config link to a Clash proxy dictionary."""
-        try:
-            scheme = protocol.lower()
-            name = f"{scheme}-{idx}"
-            if scheme == "vmess":
-                after = config.split("://", 1)[1]
-                base = after.split("#", 1)[0]
-                try:
-                    padded = base + "=" * (-len(base) % 4)
-                    data = json.loads(base64.b64decode(padded).decode())
-                    name = data.get("ps") or data.get("name") or name
-                    proxy = {
-                        "name": name,
-                        "type": "vmess",
-                        "server": data.get("add") or data.get("host", ""),
-                        "port": int(data.get("port", 0)),
-                        "uuid": data.get("id") or data.get("uuid", ""),
-                        "alterId": int(data.get("aid", 0)),
-                        "cipher": data.get("type", "auto"),
-                    }
-                    if data.get("tls") or data.get("security"):
-                        proxy["tls"] = True
-                    return proxy
-                except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
-                    logging.debug("Fallback Clash parse for vmess: %s", exc)
-                    p = urlparse(config)
-                    q = parse_qs(p.query)
-                    proxy = {
-                        "name": p.fragment or name,
-                        "type": "vmess",
-                        "server": p.hostname or "",
-                        "port": p.port or 0,
-                        "uuid": p.username or "",
-                        "alterId": int(q.get("aid", [0])[0]),
-                        "cipher": q.get("type", ["auto"])[0],
-                    }
-                    if q.get("security"):
-                        proxy["tls"] = True
-                    return proxy
-            elif scheme == "vless":
-                p = urlparse(config)
-                q = parse_qs(p.query)
-                proxy = {
-                    "name": p.fragment or name,
-                    "type": "vless",
-                    "server": p.hostname or "",
-                    "port": p.port or 0,
-                    "uuid": p.username or "",
-                    "encryption": q.get("encryption", ["none"])[0],
-                }
-                if q.get("security"):
-                    proxy["tls"] = True
-                return proxy
-            elif scheme == "reality":
-                p = urlparse(config)
-                q = parse_qs(p.query)
-                proxy = {
-                    "name": p.fragment or name,
-                    "type": "vless",
-                    "server": p.hostname or "",
-                    "port": p.port or 0,
-                    "uuid": p.username or "",
-                    "encryption": q.get("encryption", ["none"])[0],
-                    "tls": True,
-                }
-                flows = q.get("flow")
-                if flows:
-                    proxy["flow"] = flows[0]
-                return proxy
-            elif scheme == "trojan":
-                p = urlparse(config)
-                q = parse_qs(p.query)
-                proxy = {
-                    "name": p.fragment or name,
-                    "type": "trojan",
-                    "server": p.hostname or "",
-                    "port": p.port or 0,
-                    "password": p.username or p.password or "",
-                }
-                sni_vals = q.get("sni")
-                if sni_vals:
-                    proxy["sni"] = sni_vals[0]
-                if q.get("security"):
-                    proxy["tls"] = True
-                return proxy
-            elif scheme in ("ss", "shadowsocks"):
-                p = urlparse(config)
-                if p.username and p.password and p.hostname and p.port:
-                    method = p.username
-                    password = p.password
-                    server = p.hostname
-                    port = p.port
-                else:
-                    base = config.split("://", 1)[1].split("#", 1)[0]
-                    padded = base + "=" * (-len(base) % 4)
-                    decoded = base64.b64decode(padded).decode()
-                    before_at, host_port = decoded.split("@")
-                    method, password = before_at.split(":")
-                    server_str, port_str = host_port.split(":")
-                    server = server_str
-                    port = int(port_str)
-                return {
-                    "name": p.fragment or name,
-                    "type": "ss",
-                    "server": server,
-                    "port": int(port),
-                    "cipher": method,
-                    "password": password,
-                }
-            elif scheme in ("ssr", "shadowsocksr"):
-                base = config.split("://", 1)[1].split("#", 1)[0]
-                try:
-                    padded = base + "=" * (-len(base) % 4)
-                    decoded = base64.urlsafe_b64decode(padded).decode()
-                    host_part = decoded.split("/", 1)[0]
-                    if ":" not in host_part:
-                        return None
-                    server_str, port_str = host_part.split(":", 1)
-                    server = server_str
-                    port = int(port_str)
-                    return {
-                        "name": name,
-                        "type": "ssr",
-                        "server": server,
-                        "port": int(port),
-                    }
-                except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
-                    logging.debug("SSRs parse failed: %s", exc)
-                    return None
-            elif scheme == "naive":
-                p = urlparse(config)
-                if not p.hostname or not p.port:
-                    return None
-                return {
-                    "name": p.fragment or name,
-                    "type": "http",
-                    "server": p.hostname,
-                    "port": p.port,
-                    "username": p.username or "",
-                    "password": p.password or "",
-                    "tls": True,
-                }
-            else:
-                p = urlparse(config)
-                if not p.hostname or not p.port:
-                    return None
-                typ = "socks5" if scheme.startswith("socks") else "http"
-                return {
-                    "name": p.fragment or name,
-                    "type": typ,
-                    "server": p.hostname,
-                    "port": p.port,
-                }
-        except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
-            logging.debug("_config_to_clash_proxy failed: %s", exc)
-            return None
 
     def _results_to_clash_yaml(self, results: List[ConfigResult]) -> str:
         """Convert results list to Clash YAML string."""
         proxies = []
         for idx, r in enumerate(results):
-            proxy = self._config_to_clash_proxy(r.config, r.protocol, idx)
+            proxy = config_to_clash_proxy(r.config, idx, r.protocol)
             if proxy:
                 proxies.append(proxy)
         if not proxies:


### PR DESCRIPTION
## Summary
- move proxy conversion to `clash_utils.py`
- reuse `config_to_clash_proxy` in aggregator and vpn merger
- add a simple test for the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872dbc71f0c8326a0618aae43eae329