### PR TITLE
Support urlsafe base64 parsing

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -43,7 +43,7 @@ PROTOCOL_RE = re.compile(
     r")://\S+",
     re.IGNORECASE,
 )
-BASE64_RE = re.compile(r"^[A-Za-z0-9+/=]+$")
+BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
 HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
 # Safety limit for base64 decoding to avoid huge payloads
@@ -250,7 +250,8 @@ def parse_configs_from_text(text: str) -> Set[str]:
                 )
                 continue
             try:
-                decoded = base64.b64decode(line).decode()
+                padded = line + "=" * (-len(line) % 4)
+                decoded = base64.urlsafe_b64decode(padded).decode()
                 configs.update(PROTOCOL_RE.findall(decoded))
             except (binascii.Error, UnicodeDecodeError) as exc:
                 logging.debug("Failed to decode base64 line: %s", exc)

--- a/tests/test_parse_configs.py
+++ b/tests/test_parse_configs.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import base64
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
@@ -45,3 +46,9 @@ def test_parse_oversized_line(caplog):
         result = aggregator_tool.parse_configs_from_text(big_line)
     assert result == set()
     assert "Skipping oversized base64 line" in caplog.text
+
+
+def test_urlsafe_base64_line():
+    encoded = base64.urlsafe_b64encode(b"vmess://a  >").decode()
+    result = aggregator_tool.parse_configs_from_text(encoded)
+    assert result == {"vmess://a"}


### PR DESCRIPTION
## Summary
- add '-' and '_' to BASE64_RE
- decode base64 lines using `urlsafe_b64decode`
- test urlsafe base64 parsing

## Testing
- `pip install -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872dd8dc7fc8326b03fa2e1efc5af8b