### PR TITLE
Catch base64 decode errors explicitly

### DIFF
--- a/tests/test_retester_load_configs.py
+++ b/tests/test_retester_load_configs.py
@@ -35,3 +35,13 @@ def test_decode_other_error(tmp_path, monkeypatch):
     with pytest.raises(RuntimeError):
         vpn_retester.load_configs(p)
 
+
+def test_load_unicode_decode_error(tmp_path):
+    """Invalid UTF-8 bytes after base64 decoding should raise ValueError."""
+    bad_bytes = b"\xff\xff"
+    data = base64.b64encode(bad_bytes).decode()
+    p = tmp_path / "bad_utf.txt"
+    p.write_text(data, encoding="utf-8")
+    with pytest.raises(ValueError):
+        vpn_retester.load_configs(p)
+

--- a/vpn_retester.py
+++ b/vpn_retester.py
@@ -34,10 +34,13 @@ async def retest_configs(configs: List[str]) -> List[Tuple[str, Optional[float]]
 
 
 def load_configs(path: Path) -> List[str]:
+    """Load raw or base64-encoded configuration strings from ``path``."""
+
     text = path.read_text(encoding="utf-8").strip()
     if text and '://' not in text.splitlines()[0]:
         try:
-            text = base64.b64decode(text).decode("utf-8")
+            decoded_bytes = base64.b64decode(text)
+            text = decoded_bytes.decode("utf-8")
         except (binascii.Error, UnicodeDecodeError) as e:
             raise ValueError("Failed to decode base64 input") from e
     return [line.strip() for line in text.splitlines() if line.strip()]


### PR DESCRIPTION
## Summary
- raise `ValueError` only for `binascii.Error` and `UnicodeDecodeError` in `load_configs`
- verify unicode decode failures in a new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ddb3fcbc83269d34e74d30e9d279