### PR TITLE
Enforce host:port for simple config schemes

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field, fields
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterable, List, Set, Optional, Dict, Union, Tuple, cast
+from urllib.parse import urlparse
 from clash_utils import config_to_clash_proxy
 
 import yaml
@@ -111,6 +112,24 @@ def is_valid_config(link: str) -> bool:
             return False
         host = rest.split("@", 1)[1].split("/", 1)[0]
         return ":" in host
+
+    simple_host_port = {
+        "http",
+        "https",
+        "grpc",
+        "ws",
+        "wss",
+        "socks",
+        "socks4",
+        "socks5",
+        "tcp",
+        "kcp",
+        "quic",
+        "h2",
+    }
+    if scheme in simple_host_port:
+        parsed = urlparse(link)
+        return bool(parsed.hostname and parsed.port)
     if scheme == "wireguard":
         return bool(rest)
 

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -57,3 +57,8 @@ def test_ssr_basic_valid():
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}"
     assert is_valid_config(link)
+
+
+def test_http_requires_port():
+    assert not is_valid_config("http://example.com")
+    assert is_valid_config("http://example.com:8080")


### PR DESCRIPTION
## Summary
- tighten validation rules to require host and port for HTTP/HTTPS and other simple schemes
- add regression test for new validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ddc437a48326bf939ba1153d2f48