### PR TITLE
Add vmess tests and refactor config parsing

### DIFF
--- a/clash_utils.py
+++ b/clash_utils.py
@@ -15,6 +15,7 @@ def config_to_clash_proxy(
 ) -> Optional[Dict[str, Union[str, int, bool]]]:
     """Convert a single config link to a Clash proxy dictionary."""
     try:
+        q = {}
         scheme = (protocol or config.split("://", 1)[0]).lower()
         name = f"{scheme}-{idx}"
         if scheme == "vmess":
@@ -40,6 +41,7 @@ def config_to_clash_proxy(
                 logging.debug("Fallback Clash parse for vmess: %s", exc)
                 p = urlparse(config)
                 q = parse_qs(p.query)
+                security = q.get("security")
                 proxy = {
                     "name": p.fragment or name,
                     "type": "vmess",
@@ -49,12 +51,13 @@ def config_to_clash_proxy(
                     "alterId": int(q.get("aid", [0])[0]),
                     "cipher": q.get("type", ["auto"])[0],
                 }
-                if q.get("security"):
+                if security:
                     proxy["tls"] = True
                 return proxy
         elif scheme == "vless":
             p = urlparse(config)
             q = parse_qs(p.query)
+            security = q.get("security")
             proxy = {
                 "name": p.fragment or name,
                 "type": "vless",
@@ -63,12 +66,13 @@ def config_to_clash_proxy(
                 "uuid": p.username or "",
                 "encryption": q.get("encryption", ["none"])[0],
             }
-            if q.get("security"):
+            if security:
                 proxy["tls"] = True
             return proxy
         elif scheme == "reality":
             p = urlparse(config)
             q = parse_qs(p.query)
+            security = q.get("security")
             proxy = {
                 "name": p.fragment or name,
                 "type": "vless",
@@ -85,6 +89,7 @@ def config_to_clash_proxy(
         elif scheme == "trojan":
             p = urlparse(config)
             q = parse_qs(p.query)
+            security = q.get("security")
             proxy = {
                 "name": p.fragment or name,
                 "type": "trojan",
@@ -95,7 +100,7 @@ def config_to_clash_proxy(
             sni_vals = q.get("sni")
             if sni_vals:
                 proxy["sni"] = sni_vals[0]
-            if q.get("security"):
+            if security:
                 proxy["tls"] = True
             return proxy
         elif scheme in ("ss", "shadowsocks"):

--- a/tests/test_vmess_parsing.py
+++ b/tests/test_vmess_parsing.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import json
+import base64
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from clash_utils import config_to_clash_proxy
+
+
+def test_vmess_parse_success():
+    data = {
+        "add": "host",
+        "port": "443",
+        "id": "uuid",
+        "type": "auto",
+        "ps": "name",
+        "tls": "tls",
+    }
+    encoded = base64.b64encode(json.dumps(data).encode()).decode()
+    link = f"vmess://{encoded}"
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["type"] == "vmess"
+    assert proxy["server"] == "host"
+    assert proxy["port"] == 443
+    assert proxy["tls"] is True
+
+
+def test_vmess_parse_fallback():
+    link = "vmess://uuid@host:443?aid=0&type=auto&security=tls#name"
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["type"] == "vmess"
+    assert proxy["server"] == "host"
+    assert proxy["port"] == 443
+    assert proxy["tls"] is True


### PR DESCRIPTION
## Summary
- initialize `q` in `config_to_clash_proxy`
- handle `security` option inside each parsing branch
- add tests covering vmess success and fallback parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872df6d11c0832681ef2c252b691334