### PR TITLE
Normalize URLs before hashing

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -58,6 +58,13 @@ def test_create_semantic_hash_consistent_with_fragment():
     assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
 
 
+def test_create_semantic_hash_query_param_order():
+    proc = EnhancedConfigProcessor()
+    link1 = "foo://example.com/path?a=1&b=2#frag"
+    link2 = "foo://example.com/path?b=2&a=1"
+    assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
+
+
 def test_create_semantic_hash_userid_difference():
     proc = EnhancedConfigProcessor()
     link1 = make_vmess("abc")

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -44,7 +44,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 from constants import SOURCES_FILE
-from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
+from urllib.parse import urlparse, parse_qs, urlencode, urlunparse, parse_qsl
 from clash_utils import config_to_clash_proxy
 
 try:
@@ -341,8 +341,11 @@ class EnhancedConfigProcessor:
             if identifier:
                 key = f"{identifier}@{key}"
         else:
-            normalized = re.sub(r'#.*$', '', config).strip()
-            key = normalized
+            parsed = urlparse(config)
+            query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+            sorted_query = urlencode(sorted(query_pairs), doseq=True)
+            normalized = urlunparse(parsed._replace(query=sorted_query, fragment=""))
+            key = normalized.strip()
         return hashlib.sha256(key.encode()).hexdigest()[:16]
     
     async def test_connection(self, host: str, port: int) -> Optional[float]:


### PR DESCRIPTION
## Summary
- normalize URLs when hashing
- verify query string order does not change semantic hash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ea749d48832694f633eec808ddc3