### PR TITLE
Add asyncio locking and retry tests

### DIFF
--- a/tests/test_async_source_fetcher.py
+++ b/tests/test_async_source_fetcher.py
@@ -1,0 +1,83 @@
+import asyncio
+import os
+import sys
+import pytest
+
+pytest_plugins = "aiohttp.pytest_plugin"
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from vpn_merger import AsyncSourceFetcher, EnhancedConfigProcessor, CONFIG
+from aiohttp import web
+
+
+@pytest.mark.asyncio
+async def test_fetch_source_retries_on_error(aiohttp_client, monkeypatch):
+    counter = {"calls": 0}
+
+    async def handler(request):
+        counter["calls"] += 1
+        if counter["calls"] < 2:
+            return web.Response(status=500)
+        return web.Response(text="vmess://0123456789abcdef01234")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
+    fetcher.session = client.session
+
+    monkeypatch.setattr(CONFIG, "max_retries", 3)
+    url, results = await fetcher.fetch_source(client.make_url("/"))
+
+    assert counter["calls"] >= 2
+    assert len(results) == 1
+    assert results[0].config == "vmess://0123456789abcdef01234"
+
+
+@pytest.mark.asyncio
+async def test_fetch_source_timeout(aiohttp_client, monkeypatch):
+    async def handler(request):
+        await asyncio.sleep(0.1)
+        return web.Response(text="vmess://lateconfig012345")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
+    fetcher.session = client.session
+
+    monkeypatch.setattr(CONFIG, "request_timeout", 0.01)
+    monkeypatch.setattr(CONFIG, "max_retries", 1)
+    url, results = await fetcher.fetch_source(client.make_url("/"))
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_fetcher_lock_serializes_requests(aiohttp_client):
+    concurrency = 0
+    max_conc = 0
+
+    async def handler(request):
+        nonlocal concurrency, max_conc
+        concurrency += 1
+        max_conc = max(max_conc, concurrency)
+        await asyncio.sleep(0.05)
+        concurrency -= 1
+        return web.Response(text="vmess://abcdef0123456789abc")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
+    fetcher.session = client.session
+
+    await asyncio.gather(
+        fetcher.fetch_source(client.make_url("/")),
+        fetcher.fetch_source(client.make_url("/")),
+    )
+
+    assert max_conc == 1

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -463,42 +463,45 @@ class AsyncSourceFetcher:
         self.processor = processor
         self.session: Optional[aiohttp.ClientSession] = None
         self.seen_hashes = seen_hashes
+        self._lock = asyncio.Lock()
         
     async def test_source_availability(self, url: str) -> bool:
         """Test if a source URL is available (returns 200 status)."""
         assert self.session is not None
-        try:
-            timeout = aiohttp.ClientTimeout(total=10)
-            async with self.session.head(url, timeout=timeout, allow_redirects=True) as response:
-                status = response.status
-                if status == 200:
-                    return True
-                if 400 <= status < 500:
-                    async with self.session.get(
-                        url,
-                        headers={**CONFIG.headers, 'Range': 'bytes=0-0'},
-                        timeout=timeout,
-                        allow_redirects=True,
-                    ) as get_resp:
-                        return get_resp.status in (200, 206)
+        async with self._lock:
+            try:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with self.session.head(url, timeout=timeout, allow_redirects=True) as response:
+                    status = response.status
+                    if status == 200:
+                        return True
+                    if 400 <= status < 500:
+                        async with self.session.get(
+                            url,
+                            headers={**CONFIG.headers, 'Range': 'bytes=0-0'},
+                            timeout=timeout,
+                            allow_redirects=True,
+                        ) as get_resp:
+                            return get_resp.status in (200, 206)
+                    return False
+            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                logging.debug("availability check failed for %s: %s", url, exc)
                 return False
-        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            logging.debug("availability check failed for %s: %s", url, exc)
-            return False
         
     async def fetch_source(self, url: str) -> Tuple[str, List[ConfigResult]]:
         """Fetch single source with comprehensive testing and deduplication."""
         assert self.session is not None
-        for attempt in range(CONFIG.max_retries):
-            try:
-                timeout = aiohttp.ClientTimeout(total=CONFIG.request_timeout)
-                async with self.session.get(url, headers=CONFIG.headers, timeout=timeout) as response:
-                    if response.status != 200:
-                        continue
-                        
-                    content = await response.text()
-                    if not content.strip():
-                        return url, []
+        async with self._lock:
+            for attempt in range(CONFIG.max_retries):
+                try:
+                    timeout = aiohttp.ClientTimeout(total=CONFIG.request_timeout)
+                    async with self.session.get(url, headers=CONFIG.headers, timeout=timeout) as response:
+                        if response.status != 200:
+                            continue
+
+                        content = await response.text()
+                        if not content.strip():
+                            return url, []
                     
                     # Enhanced Base64 detection and decoding
                     try:
@@ -554,13 +557,12 @@ class AsyncSourceFetcher:
                     
                     return url, config_results
                     
-            except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-                logging.debug("fetch_source error on %s: %s", url, exc)
-                if attempt < CONFIG.max_retries - 1:
-                    # Use a capped and jittered delay to reduce tail latency
-                    await asyncio.sleep(min(3, 1.5 + random.random()))
-                    
-        return url, []
+                except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+                    logging.debug("fetch_source error on %s: %s", url, exc)
+                    if attempt < CONFIG.max_retries - 1:
+                        # Use a capped and jittered delay to reduce tail latency
+                        await asyncio.sleep(min(3, 1.5 + random.random()))
+            return url, []
 
 # ============================================================================
 # MAIN PROCESSOR WITH UNIFIED FUNCTIONALITY


### PR DESCRIPTION
## Summary
- add asyncio.Lock usage in `AsyncSourceFetcher`
- implement tests for retry logic, timeout handling and locking behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ea7cda7c8326861f28374b656ef2