### PR TITLE
Improve Clash proxy parsing

### DIFF
--- a/clash_utils.py
+++ b/clash_utils.py
@@ -36,6 +36,19 @@ def config_to_clash_proxy(
                 }
                 if data.get("tls") or data.get("security"):
                     proxy["tls"] = True
+                net = data.get("net") or data.get("type")
+                if net in ("ws", "grpc"):
+                    proxy["network"] = net
+                if data.get("host"):
+                    proxy["host"] = data.get("host")
+                if data.get("path"):
+                    proxy["path"] = data.get("path")
+                if data.get("sni"):
+                    proxy["sni"] = data.get("sni")
+                if data.get("fp"):
+                    proxy["fp"] = data.get("fp")
+                if data.get("flow"):
+                    proxy["flow"] = data.get("flow")
                 return proxy
             except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
                 logging.debug("Fallback Clash parse for vmess: %s", exc)
@@ -53,6 +66,12 @@ def config_to_clash_proxy(
                 }
                 if security:
                     proxy["tls"] = True
+                net = q.get("type") or q.get("mode")
+                if net:
+                    proxy["network"] = net[0]
+                for key in ("host", "path", "sni", "fp", "flow"):
+                    if key in q:
+                        proxy[key] = q[key][0]
                 return proxy
         elif scheme == "vless":
             p = urlparse(config)
@@ -68,6 +87,12 @@ def config_to_clash_proxy(
             }
             if security:
                 proxy["tls"] = True
+            net = q.get("type") or q.get("mode")
+            if net:
+                proxy["network"] = net[0]
+            for key in ("host", "path", "sni", "fp", "flow"):
+                if key in q:
+                    proxy[key] = q[key][0]
             return proxy
         elif scheme == "reality":
             p = urlparse(config)
@@ -87,6 +112,12 @@ def config_to_clash_proxy(
             flows = q.get("flow")
             if flows:
                 proxy["flow"] = flows[0]
+            net = q.get("type") or q.get("mode")
+            if net:
+                proxy["network"] = net[0]
+            for key in ("host", "path"):
+                if key in q:
+                    proxy[key] = q[key][0]
             return proxy
         elif scheme == "trojan":
             p = urlparse(config)
@@ -177,6 +208,13 @@ def config_to_clash_proxy(
                         ).decode()
                     except (binascii.Error, UnicodeDecodeError):
                         proxy["name"] = q["remarks"][0]
+                if "group" in q:
+                    try:
+                        proxy["group"] = base64.urlsafe_b64decode(
+                            q["group"][0] + "=" * (-len(q["group"][0]) % 4)
+                        ).decode()
+                    except (binascii.Error, UnicodeDecodeError):
+                        proxy["group"] = q["group"][0]
                 return proxy
             except (binascii.Error, UnicodeDecodeError, ValueError) as exc:
                 logging.debug("SSRs parse failed: %s", exc)

--- a/tests/test_aggregator_clash_proxy.py
+++ b/tests/test_aggregator_clash_proxy.py
@@ -8,14 +8,60 @@ import aggregator_tool
 
 def test_aggregator_clash_proxy(tmp_path):
     cfg = aggregator_tool.Config(output_dir=str(tmp_path), write_clash=True)
+    import base64, json
+
+    vmess_data = {
+        "add": "v.example",
+        "port": "443",
+        "id": "uuid",
+        "net": "ws",
+        "host": "host",
+        "path": "/ws",
+        "tls": "tls",
+    }
+    vmess_link = "vmess://" + base64.b64encode(json.dumps(vmess_data).encode()).decode()
+
+    vless_link = (
+        "vless://uuid@vl.example:443?type=grpc&serviceName=s&security=tls"
+        "&sni=example.com&fp=chrome#vl"
+    )
+
+    raw_ssr = (
+        "example.com:443:origin:aes-128-gcm:plain:cGFzcw==/?remarks=bmFtZQ=="
+        "&obfsparam=c2FsdA==&protoparam=YXV0aA=="
+    )
+    ssr_link = "ssr://" + base64.urlsafe_b64encode(raw_ssr.encode()).decode().strip("=")
+
     configs = [
-        "reality://uuid@host:443?flow=xtls-rprx-vision",
+        vmess_link,
+        vless_link,
+        ssr_link,
+        "reality://uuid@host:443?flow=xtls-rprx-vision&sni=site.com&fp=chrome",
         "naive://user:pass@host:443",
     ]
     aggregator_tool.output_files(configs, tmp_path, cfg)
     data = yaml.safe_load((tmp_path / "clash.yaml").read_text())
-    reality = next(p for p in data["proxies"] if p.get("flow"))
+    reality = next(p for p in data["proxies"] if p.get("flow") == "xtls-rprx-vision")
     assert reality["type"] == "vless"
     assert reality["tls"] is True
+    assert reality["sni"] == "site.com"
+    assert reality["fp"] == "chrome"
+
+    vmess = next(p for p in data["proxies"] if p["type"] == "vmess")
+    assert vmess["network"] == "ws"
+    assert vmess["host"] == "host"
+    assert vmess["path"] == "/ws"
+    assert vmess["tls"] is True
+
+    vless = next(p for p in data["proxies"] if p.get("network") == "grpc")
+    assert vless["type"] == "vless"
+    assert vless["tls"] is True
+    assert vless["fp"] == "chrome"
+
+    ssr = next(p for p in data["proxies"] if p["type"] == "ssr")
+    assert ssr["protocol"] == "origin"
+    assert ssr["obfs"] == "plain"
+    assert ssr["password"] == "pass"
+
     naive = next(p for p in data["proxies"] if p["type"] == "http")
     assert naive["tls"] is True


### PR DESCRIPTION
## Summary
- handle ws/grpc/TLS options in VLESS and VMess links
- parse Reality flow/SNI/fingerprint in Clash utils
- expose extra SSR parameters
- test aggregator output with all protocols

## Testing
- `pytest -q tests/test_aggregator_clash_proxy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ee79c31c8326bd2e01078f8f05f4