### PR TITLE
Improve fetch_text retries with backoff

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,17 +1,28 @@
 # You can set TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_BOT_TOKEN and
 # ALLOWED_USER_IDS in the environment and omit them from this file.
 {
-  "telegram_api_id": 123456,
-  "telegram_api_hash": "YOUR_HASH",
-  "telegram_bot_token": "BOT_TOKEN",
-  "allowed_user_ids": [11111111],
-  "protocols": [
-    "vmess", "vless", "trojan", "ss", "ssr", "hysteria", "hysteria2",
-    "tuic", "reality", "naive", "hy2", "wireguard"
-  ],
-  "exclude_patterns": [],
-  "output_dir": "output",
-  "log_dir": "logs",
-  "request_timeout": 10,
-  "max_concurrent": 20
+    "telegram_api_id": 123456,
+    "telegram_api_hash": "YOUR_HASH",
+    "telegram_bot_token": "BOT_TOKEN",
+    "allowed_user_ids": [11111111],
+    "protocols": [
+        "vmess",
+        "vless",
+        "trojan",
+        "ss",
+        "ssr",
+        "hysteria",
+        "hysteria2",
+        "tuic",
+        "reality",
+        "naive",
+        "hy2",
+        "wireguard",
+    ],
+    "exclude_patterns": [],
+    "output_dir": "output",
+    "log_dir": "logs",
+    "request_timeout": 10,
+    "max_concurrent": 20,
+    "settings": {"retry_attempts": 3, "retry_base_delay": 1.0},
 }

--- a/tests/test_check_sources.py
+++ b/tests/test_check_sources.py
@@ -12,7 +12,7 @@ def test_check_and_update_sources(monkeypatch, tmp_path):
     path = tmp_path / "sources.txt"
     path.write_text("good\nbad\n")
 
-    async def fake_fetch_text(session, url, timeout=10):
+    async def fake_fetch_text(session, url, timeout=10, *, retries=3, base_delay=1.0):
         if "good" in url:
             return "vmess://test"
         return None
@@ -34,7 +34,7 @@ def test_prune_after_threshold(monkeypatch, tmp_path):
     path = tmp_path / "sources.txt"
     path.write_text("onlybad\n")
 
-    async def fail_fetch(session, url, timeout=10):
+    async def fail_fetch(session, url, timeout=10, *, retries=3, base_delay=1.0):
         return None
 
     monkeypatch.setattr(aggregator_tool, "fetch_text", fail_fetch)

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -13,7 +13,7 @@ def test_load_defaults(tmp_path):
         "telegram_api_id": 1,
         "telegram_api_hash": "hash",
         "telegram_bot_token": "token",
-        "allowed_user_ids": [1]
+        "allowed_user_ids": [1],
     }
     p = tmp_path / "config.json"
     p.write_text(json.dumps(cfg))
@@ -23,6 +23,8 @@ def test_load_defaults(tmp_path):
     assert loaded.protocols == []
     assert loaded.exclude_patterns == []
     assert loaded.max_concurrent == 20
+    assert loaded.settings.retry_attempts == 3
+    assert loaded.settings.retry_base_delay == 1.0
 
 
 def test_load_invalid_json(tmp_path):
@@ -60,6 +62,16 @@ def test_custom_defaults(tmp_path):
     p.write_text(json.dumps(cfg))
     loaded = Config.load(p, defaults={"output_dir": "alt"})
     assert loaded.output_dir == "alt"
+
+
+def test_settings_custom(tmp_path):
+    p = tmp_path / "cfg.json"
+    p.write_text(
+        json.dumps({"settings": {"retry_attempts": 5, "retry_base_delay": 0.5}})
+    )
+    cfg = Config.load(p)
+    assert cfg.settings.retry_attempts == 5
+    assert cfg.settings.retry_base_delay == 0.5
 
 
 def test_env_fallback(tmp_path, monkeypatch):

--- a/tests/test_scrape_telegram_configs.py
+++ b/tests/test_scrape_telegram_configs.py
@@ -34,7 +34,7 @@ class DummyClient:
         pass
 
 
-async def fake_fetch_text(session, url, timeout=10):
+async def fake_fetch_text(session, url, timeout=10, *, retries=3, base_delay=1.0):
     if "sub.example" in url:
         return "vmess://from_url"
     return None
@@ -52,7 +52,9 @@ def test_scrape_telegram_configs(monkeypatch, tmp_path):
     monkeypatch.setattr(aggregator_tool, "TelegramClient", DummyClient)
     monkeypatch.setattr(aggregator_tool, "Message", DummyMessage)
     monkeypatch.setattr(aggregator_tool, "fetch_text", fake_fetch_text)
-    monkeypatch.setattr(aggregator_tool, "errors", types.SimpleNamespace(RPCError=Exception))
+    monkeypatch.setattr(
+        aggregator_tool, "errors", types.SimpleNamespace(RPCError=Exception)
+    )
 
     result = asyncio.run(aggregator_tool.scrape_telegram_configs(channels, 24, cfg))
     assert result == {"vmess://direct1", "vmess://from_url", "http://sub.example"}


### PR DESCRIPTION
## Summary
- introduce `Settings` dataclass for HTTP retry options
- implement exponential backoff with jitter in `fetch_text`
- stop retrying on 4xx errors
- allow configuration of retry count and delay
- update tests for new arguments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f094762c8326b6f53a306fddaf1b