### PR TITLE
Normalize URL hashing

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -73,6 +73,13 @@ def test_create_semantic_hash_query_param_order():
     assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
 
 
+def test_create_semantic_hash_fragment_ignored_generic():
+    proc = EnhancedConfigProcessor()
+    link1 = "foo://example.com/path?a=1&b=2"
+    link2 = "foo://example.com/path?a=1&b=2#extra"
+    assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
+
+
 def test_create_semantic_hash_vmess_key_order():
     proc = EnhancedConfigProcessor()
     d1 = {"add": "ex.com", "port": 80, "id": "abc"}

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -241,6 +241,13 @@ class EnhancedConfigProcessor:
         self.dns_cache = {}
         self.resolver: Optional[AsyncResolver] = None
         self._geoip_reader = None
+
+    def _normalize_url(self, config: str) -> str:
+        """Return URL with sorted query params and no fragment."""
+        parsed = urlparse(config)
+        query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
+        sorted_query = urlencode(sorted(query_pairs), doseq=True)
+        return urlunparse(parsed._replace(query=sorted_query, fragment=""))
         
     def extract_host_port(self, config: str) -> Tuple[Optional[str], Optional[int]]:
         """Extract host and port from configuration for testing."""
@@ -290,9 +297,7 @@ class EnhancedConfigProcessor:
     def create_semantic_hash(self, config: str) -> str:
         """Create semantic hash for intelligent deduplication."""
         parsed = urlparse(config)
-        query_pairs = parse_qsl(parsed.query, keep_blank_values=True)
-        sorted_query = urlencode(sorted(query_pairs), doseq=True)
-        normalized_config = urlunparse(parsed._replace(query=sorted_query, fragment=""))
+        normalized_config = self._normalize_url(config)
 
         host, port = self.extract_host_port(normalized_config)
         identifier = None


### PR DESCRIPTION
## Summary
- normalize URLs before hashing
- test hashing ignores fragments for any scheme

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6872f0a5f3048326a90a80b7186e47b1