### PR TITLE
Introduce unified Pydantic settings

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,110 @@
+# Example configuration for MassConfigMerger
+# Telegram credentials (optional)
+telegram_api_id: 123456
+telegram_api_hash: YOUR_HASH
+telegram_bot_token: BOT_TOKEN
+allowed_user_ids:
+  - 11111111
+
+# Aggregator options
+protocols:
+  - vmess
+  - vless
+  - trojan
+  - ss
+  - ssr
+  - hysteria
+  - hysteria2
+  - tuic
+  - reality
+  - naive
+  - hy2
+  - wireguard
+exclude_patterns: []
+output_dir: output
+log_dir: logs
+request_timeout: 10  # HTTP request timeout in seconds
+concurrent_limit: 20
+retry_attempts: 3
+retry_base_delay: 1.0
+write_base64: true
+write_singbox: true
+write_clash: true
+
+# Merger options
+headers:
+  User-Agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+  Accept-Language: "en-US,en;q=0.5"
+  Connection: "keep-alive"
+  Cache-Control: "no-cache"
+connect_timeout: 3.0
+max_retries: 3
+max_configs_per_source: 75000
+valid_prefixes:
+  - vmess://
+  - vless://
+  - reality://
+  - ss://
+  - ssr://
+  - trojan://
+  - hy2://
+  - hysteria://
+  - hysteria2://
+  - tuic://
+  - shadowtls://
+  - wireguard://
+  - socks://
+  - socks4://
+  - socks5://
+  - http://
+  - https://
+  - grpc://
+  - ws://
+  - wss://
+  - tcp://
+  - kcp://
+  - quic://
+  - h2://
+enable_url_testing: true
+enable_sorting: true
+test_timeout: 5.0
+batch_size: 1000
+threshold: 0
+top_n: 0
+tls_fragment: null
+include_protocols:
+  - PROXY
+  - SHADOWSOCKS
+  - SHADOWSOCKSR
+  - TROJAN
+  - CLASH
+  - V2RAY
+  - REALITY
+  - VMESS
+  - XRAY
+  - WIREGUARD
+  - ECH
+  - VLESS
+  - HYSTERIA
+  - TUIC
+  - SING-BOX
+  - SINGBOX
+  - SHADOWTLS
+  - CLASHMETA
+  - HYSTERIA2
+exclude_protocols:
+  - OTHER
+resume_file: null
+max_ping_ms: 1000
+log_file: null
+cumulative_batches: false
+strict_batch: true
+shuffle_sources: false
+write_csv: true
+write_clash_proxies: true
+mux_concurrency: 8
+smux_streams: 4
+geoip_db: null
+include_countries: null
+exclude_countries: null

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+import yaml
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AppConfig(BaseSettings):
+    """Application configuration loaded from YAML with env overrides."""
+
+    # Telegram / aggregator settings
+    telegram_api_id: Optional[int] = None
+    telegram_api_hash: Optional[str] = None
+    telegram_bot_token: Optional[str] = None
+    allowed_user_ids: List[int] = []
+
+    protocols: List[str] = []
+    exclude_patterns: List[str] = []
+    output_dir: str = "output"
+    log_dir: str = "logs"
+    request_timeout: int = 10
+    concurrent_limit: int = 20
+    retry_attempts: int = 3
+    retry_base_delay: float = 1.0
+    write_base64: bool = True
+    write_singbox: bool = True
+    write_clash: bool = True
+
+    # Merger settings
+    headers: Dict[str, str] = {
+        "User-Agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/125.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Connection": "keep-alive",
+        "Cache-Control": "no-cache",
+    }
+    connect_timeout: float = 3.0
+    max_retries: int = 3
+    max_configs_per_source: int = 75000
+    valid_prefixes: Tuple[str, ...] = (
+        "vmess://",
+        "vless://",
+        "reality://",
+        "ss://",
+        "ssr://",
+        "trojan://",
+        "hy2://",
+        "hysteria://",
+        "hysteria2://",
+        "tuic://",
+        "shadowtls://",
+        "wireguard://",
+        "socks://",
+        "socks4://",
+        "socks5://",
+        "http://",
+        "https://",
+        "grpc://",
+        "ws://",
+        "wss://",
+        "tcp://",
+        "kcp://",
+        "quic://",
+        "h2://",
+    )
+    enable_url_testing: bool = True
+    enable_sorting: bool = True
+    test_timeout: float = 5.0
+    batch_size: int = 1000
+    threshold: int = 0
+    top_n: int = 0
+    tls_fragment: Optional[str] = None
+    include_protocols: Optional[Set[str]] = {
+        "PROXY",
+        "SHADOWSOCKS",
+        "SHADOWSOCKSR",
+        "TROJAN",
+        "CLASH",
+        "V2RAY",
+        "REALITY",
+        "VMESS",
+        "XRAY",
+        "WIREGUARD",
+        "ECH",
+        "VLESS",
+        "HYSTERIA",
+        "TUIC",
+        "SING-BOX",
+        "SINGBOX",
+        "SHADOWTLS",
+        "CLASHMETA",
+        "HYSTERIA2",
+    }
+    exclude_protocols: Optional[Set[str]] = {"OTHER"}
+    resume_file: Optional[str] = None
+    max_ping_ms: Optional[int] = 1000
+    log_file: Optional[str] = None
+    cumulative_batches: bool = False
+    strict_batch: bool = True
+    shuffle_sources: bool = False
+    write_csv: bool = True
+    write_clash_proxies: bool = True
+    mux_concurrency: int = 8
+    smux_streams: int = 4
+    geoip_db: Optional[str] = None
+    include_countries: Optional[Set[str]] = None
+    exclude_countries: Optional[Set[str]] = None
+
+    model_config = SettingsConfigDict(env_prefix="")
+
+    @classmethod
+    def settings_customise_sources(cls, settings_cls, init_settings, env_settings, dotenv_settings, file_secret_settings):
+        return init_settings,
+
+    @classmethod
+    def load(cls, path: Path, defaults: dict | None = None) -> "AppConfig":
+        """Load configuration from a YAML file applying defaults and env vars."""
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except FileNotFoundError as exc:
+            raise ValueError(f"Config file not found: {path}") from exc
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
+
+        if defaults:
+            for k, v in defaults.items():
+                data.setdefault(k, v)
+
+        env = os.getenv
+        env_map = {
+            "telegram_api_id": env("TELEGRAM_API_ID"),
+            "telegram_api_hash": env("TELEGRAM_API_HASH"),
+            "telegram_bot_token": env("TELEGRAM_BOT_TOKEN"),
+            "allowed_user_ids": env("ALLOWED_USER_IDS"),
+        }
+        if env_map["telegram_api_id"] is not None:
+            try:
+                data["telegram_api_id"] = int(env_map["telegram_api_id"])
+            except ValueError as exc:
+                raise ValueError("TELEGRAM_API_ID must be an integer") from exc
+        for key in ("telegram_api_hash", "telegram_bot_token"):
+            if env_map[key] is not None:
+                data[key] = env_map[key]
+        if env_map["allowed_user_ids"] is not None:
+            try:
+                ids = [
+                    int(i)
+                    for i in re.split(r"[ ,]+", env_map["allowed_user_ids"].strip())
+                    if i
+                ]
+            except ValueError as exc:
+                raise ValueError(
+                    "ALLOWED_USER_IDS must be a comma separated list of integers"
+                ) from exc
+            data["allowed_user_ids"] = ids
+
+        if "allowed_user_ids" in data:
+            try:
+                data["allowed_user_ids"] = [int(i) for i in data["allowed_user_ids"]]
+            except Exception as exc:
+                raise ValueError("allowed_user_ids must be a list of integers") from exc
+
+        return cls(**data)

--- a/tests/test_aggregation_merging.py
+++ b/tests/test_aggregation_merging.py
@@ -36,7 +36,7 @@ async def test_fetch_and_parse_configs_handles_errors(aiohttp_client, tmp_path):
     ]
 
     configs = await aggregator_tool.fetch_and_parse_configs(
-        urls, max_concurrent=3, request_timeout=0.05
+        urls, concurrent_limit=3, request_timeout=0.05
     )
     assert configs == {"vmess://good"}
 

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -1,4 +1,5 @@
 import json
+import yaml
 import os
 import sys
 from pathlib import Path
@@ -15,16 +16,16 @@ def test_load_defaults(tmp_path):
         "telegram_bot_token": "token",
         "allowed_user_ids": [1],
     }
-    p = tmp_path / "config.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     loaded = Config.load(p)
     assert loaded.output_dir == "output"
     assert loaded.log_dir == "logs"
     assert loaded.protocols == []
     assert loaded.exclude_patterns == []
-    assert loaded.max_concurrent == 20
-    assert loaded.settings.retry_attempts == 3
-    assert loaded.settings.retry_base_delay == 1.0
+    assert loaded.concurrent_limit == 20
+    assert loaded.retry_attempts == 3
+    assert loaded.retry_base_delay == 1.0
 
 
 def test_load_invalid_json(tmp_path):
@@ -58,24 +59,24 @@ def test_custom_defaults(tmp_path):
         "telegram_bot_token": "token",
         "allowed_user_ids": [1],
     }
-    p = tmp_path / "config.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     loaded = Config.load(p, defaults={"output_dir": "alt"})
     assert loaded.output_dir == "alt"
 
 
 def test_settings_custom(tmp_path):
-    p = tmp_path / "cfg.json"
+    p = tmp_path / "cfg.yaml"
     p.write_text(
-        json.dumps({"settings": {"retry_attempts": 5, "retry_base_delay": 0.5}})
+        yaml.safe_dump({"retry_attempts": 5, "retry_base_delay": 0.5})
     )
     cfg = Config.load(p)
-    assert cfg.settings.retry_attempts == 5
-    assert cfg.settings.retry_base_delay == 0.5
+    assert cfg.retry_attempts == 5
+    assert cfg.retry_base_delay == 0.5
 
 
 def test_env_fallback(tmp_path, monkeypatch):
-    p = tmp_path / "config.json"
+    p = tmp_path / "config.yaml"
     p.write_text("{}")
     monkeypatch.setenv("TELEGRAM_API_ID", "42")
     monkeypatch.setenv("TELEGRAM_API_HASH", "hash")
@@ -95,8 +96,8 @@ def test_env_override(tmp_path, monkeypatch):
         "telegram_bot_token": "token",
         "allowed_user_ids": [1],
     }
-    p = tmp_path / "config.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     monkeypatch.setenv("TELEGRAM_API_ID", "99")
     monkeypatch.setenv("TELEGRAM_API_HASH", "newhash")
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "newtoken")
@@ -112,8 +113,8 @@ def test_allowed_ids_env_fallback(tmp_path, monkeypatch):
         "telegram_api_hash": "hash",
         "telegram_bot_token": "token",
     }
-    p = tmp_path / "c.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     monkeypatch.setenv("ALLOWED_USER_IDS", "5,6")
     loaded = Config.load(p)
     assert loaded.allowed_user_ids == [5, 6]
@@ -126,8 +127,8 @@ def test_allowed_ids_env_override(tmp_path, monkeypatch):
         "telegram_bot_token": "token",
         "allowed_user_ids": [1],
     }
-    p = tmp_path / "c.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     monkeypatch.setenv("ALLOWED_USER_IDS", "2 3")
     loaded = Config.load(p)
     assert loaded.allowed_user_ids == [2, 3]
@@ -140,7 +141,7 @@ def test_allowed_ids_string_values(tmp_path):
         "telegram_bot_token": "token",
         "allowed_user_ids": ["7", "8"],
     }
-    p = tmp_path / "cfg.json"
-    p.write_text(json.dumps(cfg))
+    p = tmp_path / "cfg.yaml"
+    p.write_text(yaml.safe_dump(cfg))
     loaded = Config.load(p)
     assert loaded.allowed_user_ids == [7, 8]

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import yaml
 from pathlib import Path
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -36,8 +37,8 @@ def test_cli_flags_override(monkeypatch, tmp_path):
         "write_singbox": True,
         "write_clash": True,
     }
-    cfg_path = tmp_path / "config.json"
-    cfg_path.write_text(json.dumps(cfg_data))
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg_data))
 
     recorded = {}
 
@@ -72,8 +73,8 @@ def test_cli_flags_override(monkeypatch, tmp_path):
 
 
 def test_cli_no_prune(monkeypatch, tmp_path):
-    cfg_path = tmp_path / "c.json"
-    cfg_path.write_text(json.dumps({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
+    cfg_path = tmp_path / "c.yaml"
+    cfg_path.write_text(yaml.safe_dump({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
 
     recorded = {}
 
@@ -97,8 +98,8 @@ def test_cli_no_prune(monkeypatch, tmp_path):
 
 
 def test_cli_with_merger(monkeypatch, tmp_path):
-    cfg_path = tmp_path / "c.json"
-    cfg_path.write_text(json.dumps({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
+    cfg_path = tmp_path / "c.yaml"
+    cfg_path.write_text(yaml.safe_dump({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
 
     files = [tmp_path / "o" / "merged.txt", tmp_path / "o" / "merged_base64.txt"]
 
@@ -131,8 +132,8 @@ def test_cli_with_merger(monkeypatch, tmp_path):
 
 
 def test_cli_protocols_case_insensitive(monkeypatch, tmp_path):
-    cfg_path = tmp_path / "cfg.json"
-    cfg_path.write_text(json.dumps({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(yaml.safe_dump({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
 
     recorded = {}
 

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -47,6 +47,11 @@ from constants import SOURCES_FILE
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse, parse_qsl
 from clash_utils import config_to_clash_proxy
 
+SRC_PATH = Path(__file__).resolve().parent / "src"
+if SRC_PATH.is_dir():
+    sys.path.insert(0, str(SRC_PATH))
+from massconfigmerger.config import AppConfig as Config
+
 try:
     import aiohttp
     from aiohttp.resolver import AsyncResolver
@@ -80,114 +85,11 @@ except ImportError as exc:
 # CONFIGURATION & SETTINGS
 # ============================================================================
 
-@dataclass
-class Config:
-    """Comprehensive configuration for optimal performance."""
-    
-    # HTTP settings
-    headers: Dict[str, str]
-    request_timeout: int
-    connect_timeout: float
-    max_retries: int
-    
-    # Processing settings
-    concurrent_limit: int
-    max_configs_per_source: int
-    
-    # Protocol validation
-    valid_prefixes: Tuple[str, ...]
-    
-    # Testing settings
-    enable_url_testing: bool
-    enable_sorting: bool
-    test_timeout: float
-
-    # Output settings
-    output_dir: str
-
-    # New features
-    batch_size: int
-    threshold: int
-    top_n: int
-    tls_fragment: Optional[str]
-    include_protocols: Optional[Set[str]]
-    exclude_protocols: Optional[Set[str]]
-    exclude_patterns: List[str]
-    resume_file: Optional[str]
-    max_ping_ms: Optional[int]
-    log_file: Optional[str]
-    cumulative_batches: bool
-    strict_batch: bool
-    shuffle_sources: bool
-    write_base64: bool
-    write_csv: bool
-    write_clash: bool
-    write_clash_proxies: bool
-    mux_concurrency: int
-    smux_streams: int
-    geoip_db: Optional[str] = None
-    include_countries: Optional[Set[str]] = None
-    exclude_countries: Optional[Set[str]] = None
-
-CONFIG = Config(
-    headers={
-        "User-Agent": (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/125.0.0.0 Safari/537.36"
-        ),
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.5",
-        "Connection": "keep-alive",
-        "Cache-Control": "no-cache",
-    },
-    request_timeout=30,
-    connect_timeout=3.0,
-    max_retries=3,
-    concurrent_limit=50,
-    max_configs_per_source=75000,
-    valid_prefixes=(
-        "vmess://", "vless://", "reality://",
-        "ss://", "ssr://", "trojan://",
-        "hy2://", "hysteria://", "hysteria2://",
-        "tuic://", "shadowtls://", "wireguard://",
-        "socks://", "socks4://", "socks5://",
-        "http://", "https://", "grpc://", "ws://", "wss://",
-        "tcp://", "kcp://", "quic://", "h2://",
-    ),
-    enable_url_testing=True,
-    enable_sorting=True,
-    test_timeout=5.0,
-    output_dir="output",
-    batch_size=1000,
-    threshold=0,
-    top_n=0,
-    tls_fragment=None,
-    include_protocols={
-        "PROXY", "SHADOWSOCKS", "SHADOWSOCKSR", "TROJAN",
-        "CLASH", "V2RAY", "REALITY",
-        "VMESS", "XRAY", "WIREGUARD", "ECH", "VLESS",
-        "HYSTERIA", "TUIC", "SING-BOX", "SINGBOX",
-        "SHADOWTLS", "CLASHMETA", "HYSTERIA2",
-    },
-    exclude_protocols={"OTHER"},
-    exclude_patterns=[],
-    resume_file=None,
-    max_ping_ms=1000,
-    log_file=None,
-    cumulative_batches=False,
-    strict_batch=True,
-    shuffle_sources=False,
-    write_base64=True,
-    write_csv=True,
-    write_clash=True,
-    write_clash_proxies=True,
-    mux_concurrency=8,
-    smux_streams=4,
-    geoip_db=None,
-    include_countries=None,
-    exclude_countries=None
-)
+DEFAULT_CONFIG_FILE = Path(__file__).resolve().with_name("config.yaml")
+try:
+    CONFIG = Config.load(DEFAULT_CONFIG_FILE)
+except ValueError:
+    CONFIG = Config()
 
 # Compiled regular expressions from --exclude-pattern
 EXCLUDE_REGEXES: List[re.Pattern] = []


### PR DESCRIPTION
## Summary
- add `AppConfig` in `src/massconfigmerger/config.py`
- use new settings in `aggregator_tool`, `vpn_merger` and `vpn_retester`
- provide example `config.yaml.example`
- update tests for unified configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68735278d7e88326ab3e347ba3a97a32