### PR TITLE
Allow arbitrary output and log directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,9 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
    python aggregator_tool.py --hours 12
    ```
    The aggregated configuration links will be written to the folder specified in
-   `output_dir` (default `output/`) as `merged.txt`. Depending on the
+   `output_dir` (default `output/` in this repository) as `merged.txt`. Any
+   absolute or relative path may be used and missing directories will be
+   created. Depending on the
    `write_base64`, `write_singbox` and `write_clash` options—overridable with the
    flags above—the files `merged_base64.txt`, `merged_singbox.json` and
    `clash.yaml` may also be created.
@@ -739,8 +741,8 @@ When provided, environment variables take precedence over the file values.
 Optional fields use these defaults when omitted:
 - `protocols` – `[]`
 - `exclude_patterns` – `[]`
-- `output_dir` – `output`
-- `log_dir` – `logs`
+- `output_dir` – `output` (relative to this folder)
+- `log_dir` – `logs` (relative to this folder)
 - `request_timeout` – `10`
 - `max_concurrent` – `20`
 - `write_base64` – `true`
@@ -749,8 +751,8 @@ Optional fields use these defaults when omitted:
 
 - **protocols** – only links starting with these schemes are kept.
 - **exclude_patterns** – regular expressions to remove unwanted links.
-- **output_dir** – where merged files are created.
-- **log_dir** – daily log files are written here.
+- **output_dir** – where merged files are created. May be any path.
+- **log_dir** – daily log files are written here. May be any path.
 - **request_timeout** – HTTP request timeout in seconds (override with `--request-timeout`).
 - **max_concurrent** – maximum simultaneous HTTP requests for validating and fetching sources (override with `--concurrent-limit`).
 - **write_base64** – create `merged_base64.txt` when `true`.
@@ -771,8 +773,8 @@ that file.
   updates.
 - When scraping Telegram make sure you only access **public** channels and
   respect Telegram's Terms of Service along with your local laws.
-- All events are logged to the directory specified in `log_dir` so you can audit
-  what was fetched and from where.
+- All events are logged to the directory specified in `log_dir` (defaults to
+  `logs/` here) so you can audit what was fetched and from where.
 ## FAQ
 
 ### Why does the script take so long?

--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -827,19 +827,12 @@ def main() -> None:
     if args.no_clash:
         cfg.write_clash = False
 
-    allowed_base = _get_script_dir()
     resolved_output = Path(cfg.output_dir).expanduser().resolve()
-    try:
-        resolved_output.relative_to(allowed_base)
-    except ValueError:
-        parser.error(f"--output-dir must be within {allowed_base}")
+    resolved_output.mkdir(parents=True, exist_ok=True)
     cfg.output_dir = str(resolved_output)
 
     resolved_log_dir = Path(cfg.log_dir).expanduser().resolve()
-    try:
-        resolved_log_dir.relative_to(allowed_base)
-    except ValueError:
-        parser.error(f"log_dir must be within {allowed_base}")
+    resolved_log_dir.mkdir(parents=True, exist_ok=True)
     cfg.log_dir = str(resolved_log_dir)
 
     if args.protocols:

--- a/tests/test_cli_country_flags.py
+++ b/tests/test_cli_country_flags.py
@@ -13,7 +13,6 @@ def test_cli_country_flags(monkeypatch, tmp_path):
         return None
 
     monkeypatch.setattr(vpn_merger, "detect_and_run", fake_detect_and_run)
-    monkeypatch.setattr(vpn_merger, "_get_script_dir", lambda: tmp_path)
     monkeypatch.setattr(CONFIG, "include_countries", None)
     monkeypatch.setattr(CONFIG, "exclude_countries", None)
     monkeypatch.setattr(sys, "argv", [

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -48,7 +48,6 @@ def test_cli_flags_override(monkeypatch, tmp_path):
 
     monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
-    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
     monkeypatch.setattr(sys, "argv", [
         "aggregator_tool.py",
         "--config",
@@ -83,7 +82,6 @@ def test_cli_no_prune(monkeypatch, tmp_path):
 
     monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
-    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
     monkeypatch.setattr(sys, "argv", [
         "aggregator_tool.py",
         "--config",
@@ -115,7 +113,6 @@ def test_cli_with_merger(monkeypatch, tmp_path):
 
     monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
-    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
     monkeypatch.setattr(aggregator_tool.vpn_merger, "detect_and_run", fake_detect_and_run)
     monkeypatch.setattr(sys, "argv", [
         "aggregator_tool.py",
@@ -142,7 +139,6 @@ def test_cli_protocols_case_insensitive(monkeypatch, tmp_path):
 
     monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
     monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
-    monkeypatch.setattr(aggregator_tool, "_get_script_dir", lambda: tmp_path)
     monkeypatch.setattr(sys, "argv", [
         "aggregator_tool.py",
         "--config",

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -1375,13 +1375,9 @@ def main():
     global EXCLUDE_REGEXES
     EXCLUDE_REGEXES = [re.compile(p) for p in CONFIG.exclude_patterns]
     CONFIG.resume_file = args.resume
-    # Resolve and validate output directory to prevent path traversal
-    allowed_base = _get_script_dir()
+    # Resolve and create output directory if needed
     resolved_output = Path(args.output_dir).expanduser().resolve()
-    try:
-        resolved_output.relative_to(allowed_base)
-    except ValueError:
-        parser.error(f"--output-dir must be within {allowed_base}")
+    resolved_output.mkdir(parents=True, exist_ok=True)
     CONFIG.output_dir = str(resolved_output)
     CONFIG.test_timeout = max(0.1, args.test_timeout)
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)


### PR DESCRIPTION
## Summary
- stop restricting paths with `_get_script_dir`
- resolve `--output-dir` and `log_dir` and create directories if missing
- document that default paths are relative to repo but any location is allowed
- update CLI tests now that `_get_script_dir` is unused

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687352ab2cbc8326a40b38c4acf3caf8