### PR TITLE
Unify configuration system

### DIFF
--- a/aggregator_tool.py
+++ b/aggregator_tool.py
@@ -36,7 +36,7 @@ from constants import SOURCES_FILE
 SRC_PATH = Path(__file__).resolve().parent / "src"
 if SRC_PATH.is_dir():
     sys.path.insert(0, str(SRC_PATH))
-from massconfigmerger.config import AppConfig as Config
+from massconfigmerger.config import Settings, load_config
 
 CONFIG_FILE = Path("config.yaml")
 CHANNELS_FILE = Path("channels.txt")
@@ -330,7 +330,7 @@ async def fetch_and_parse_configs(
 
 
 async def scrape_telegram_configs(
-    channels_path: Path, last_hours: int, cfg: Config
+    channels_path: Path, last_hours: int, cfg: Settings
 ) -> Set[str]:
     """Scrape telegram channels for configs."""
     if cfg.telegram_api_id is None or cfg.telegram_api_hash is None:
@@ -415,7 +415,7 @@ async def scrape_telegram_configs(
 
 
 def deduplicate_and_filter(
-    config_set: Set[str], cfg: Config, protocols: List[str] | None = None
+    config_set: Set[str], cfg: Settings, protocols: List[str] | None = None
 ) -> List[str]:
     """Apply filters and return sorted configs.
 
@@ -448,7 +448,7 @@ def deduplicate_and_filter(
     return final
 
 
-def output_files(configs: List[str], out_dir: Path, cfg: Config) -> List[Path]:
+def output_files(configs: List[str], out_dir: Path, cfg: Settings) -> List[Path]:
     """Write merged files and return list of written file paths respecting cfg flags."""
     out_dir.mkdir(parents=True, exist_ok=True)
     written: List[Path] = []
@@ -515,7 +515,7 @@ def output_files(configs: List[str], out_dir: Path, cfg: Config) -> List[Path]:
 
 
 async def run_pipeline(
-    cfg: Config,
+    cfg: Settings,
     protocols: List[str] | None = None,
     sources_file: Path = SOURCES_FILE,
     channels_file: Path = CHANNELS_FILE,
@@ -560,7 +560,7 @@ async def run_pipeline(
 
 
 async def telegram_bot_mode(
-    cfg: Config,
+    cfg: Settings,
     sources_file: Path = SOURCES_FILE,
     channels_file: Path = CHANNELS_FILE,
     last_hours: int = 24,
@@ -698,7 +698,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    cfg = Config.load(Path(args.config))
+    cfg = load_config(Path(args.config))
     if args.output_dir:
         cfg.output_dir = args.output_dir
     if args.concurrent_limit is not None:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,7 @@
 # Example configuration for MassConfigMerger
+# Copy to ``config.yaml`` and edit as needed.
+# Each option can also be overridden using an environment variable
+# of the same name.
 # Telegram credentials (optional)
 telegram_api_id: 123456
 telegram_api_hash: YOUR_HASH

--- a/tests/test_aggregator_clash_proxy.py
+++ b/tests/test_aggregator_clash_proxy.py
@@ -4,10 +4,11 @@ import yaml
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
+from massconfigmerger.config import Settings
 
 
 def test_aggregator_clash_proxy(tmp_path):
-    cfg = aggregator_tool.Config(output_dir=str(tmp_path), write_clash=True)
+    cfg = Settings(output_dir=str(tmp_path), write_clash=True)
     import base64, json
 
     vmess_data = {

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -5,6 +5,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
+from massconfigmerger.config import Settings
 
 
 def test_case_insensitive_deduplication():
@@ -12,7 +13,7 @@ def test_case_insensitive_deduplication():
     b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
     lower = f"vmess://{b64}"
     upper = f"Vmess://{b64}"
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",
@@ -26,7 +27,7 @@ def test_case_insensitive_deduplication():
 
 def test_exclude_patterns_ignore_case():
     link = "trojan://pw@foo.com:443"
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",
@@ -43,7 +44,7 @@ def test_empty_protocol_list_accepts_all():
     b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
     vmess = f"vmess://{b64}"
     trojan = "trojan://pw@foo.com:443"
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",
@@ -59,7 +60,7 @@ def test_protocol_filter_mixed_case_from_cfg():
     b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
     vmess = f"vmess://{b64}"
     trojan = "trojan://pw@foo.com:443"
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",
@@ -75,7 +76,7 @@ def test_protocol_filter_mixed_case_argument():
     b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")
     vmess = f"vmess://{b64}"
     trojan = "trojan://pw@foo.com:443"
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -6,24 +6,25 @@ from pathlib import Path
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
+from massconfigmerger.config import Settings
 
 
 def test_output_files_skip_base64(tmp_path):
-    cfg = aggregator_tool.Config(write_base64=False)
+    cfg = Settings(write_base64=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
     assert (tmp_path / "merged.txt").exists()
     assert not (tmp_path / "merged_base64.txt").exists()
 
 
 def test_output_files_skip_singbox(tmp_path):
-    cfg = aggregator_tool.Config(write_singbox=False)
+    cfg = Settings(write_singbox=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
     assert (tmp_path / "merged.txt").exists()
     assert not (tmp_path / "merged_singbox.json").exists()
 
 
 def test_output_files_skip_clash(tmp_path):
-    cfg = aggregator_tool.Config(write_clash=False)
+    cfg = Settings(write_clash=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
     assert (tmp_path / "merged.txt").exists()
     assert not (tmp_path / "clash.yaml").exists()

--- a/tests/test_scrape_telegram_configs.py
+++ b/tests/test_scrape_telegram_configs.py
@@ -5,6 +5,7 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 import aggregator_tool
+from massconfigmerger.config import Settings
 
 
 class DummyMessage:
@@ -43,7 +44,7 @@ async def fake_fetch_text(session, url, timeout=10, *, retries=3, base_delay=1.0
 def test_scrape_telegram_configs(monkeypatch, tmp_path):
     channels = tmp_path / "channels.txt"
     channels.write_text("chan1\n")
-    cfg = aggregator_tool.Config(
+    cfg = Settings(
         telegram_api_id=1,
         telegram_api_hash="h",
         telegram_bot_token="t",

--- a/vpn_merger.py
+++ b/vpn_merger.py
@@ -50,7 +50,7 @@ from clash_utils import config_to_clash_proxy
 SRC_PATH = Path(__file__).resolve().parent / "src"
 if SRC_PATH.is_dir():
     sys.path.insert(0, str(SRC_PATH))
-from massconfigmerger.config import AppConfig as Config
+from massconfigmerger.config import Settings, load_config
 
 try:
     import aiohttp
@@ -87,9 +87,9 @@ except ImportError as exc:
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().with_name("config.yaml")
 try:
-    CONFIG = Config.load(DEFAULT_CONFIG_FILE)
+    CONFIG = load_config(DEFAULT_CONFIG_FILE)
 except ValueError:
-    CONFIG = Config()
+    CONFIG = Settings()
 
 # Compiled regular expressions from --exclude-pattern
 EXCLUDE_REGEXES: List[re.Pattern] = []


### PR DESCRIPTION
## Summary
- move all config fields into `Settings` model and add `load_config`
- switch aggregator_tool and vpn_merger to use the unified loader
- document environment overrides in `config.yaml.example`
- update tests for new configuration API

## Testing
- `pip install pydantic pydantic-settings`
- `pip install aiohttp aiodns PyYAML`
- `pip install telethon nest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873576f19188326a76601bf4ab2a23e