### PR TITLE
Enhance Clash proxy parser

### DIFF
--- a/tests/test_clash_parsing_extra.py
+++ b/tests/test_clash_parsing_extra.py
@@ -7,7 +7,11 @@ from clash_utils import config_to_clash_proxy
 
 
 def test_ssr_parse_success():
-    raw = "example.com:443:origin:aes-128-gcm:plain:cGFzcw==/?remarks=bmFtZQ==&obfsparam=c2FsdA==&protoparam=YXV0aA=="
+    raw = (
+        "example.com:443:origin:aes-128-gcm:plain:cGFzcw==/"
+        "?remarks=bmFtZQ==&obfsparam=c2FsdA==&protoparam=YXV0aA=="
+        "&udpport=53&uot=1&group=Z3Jw"
+    )
     b64 = base64.urlsafe_b64encode(raw.encode()).decode().strip("=")
     link = f"ssr://{b64}"
     proxy = config_to_clash_proxy(link, 0)
@@ -21,6 +25,9 @@ def test_ssr_parse_success():
     assert proxy["obfs-param"] == "salt"
     assert proxy["protocol-param"] == "auth"
     assert proxy["name"] == "name"
+    assert proxy["udpport"] == 53
+    assert proxy["uot"] == "1"
+    assert proxy["group"] == "grp"
 
 
 def test_ssr_parse_invalid():
@@ -44,7 +51,7 @@ def test_reality_parse_extra():
 
 
 def test_hysteria2_parse():
-    link = "hy2://pass@host:443?peer=example.com&insecure=1"
+    link = "hy2://pass@host:443?peer=example.com&insecure=1&upmbps=10&downmbps=20"
     proxy = config_to_clash_proxy(link, 0)
     assert proxy["type"] == "hysteria2"
     assert proxy["server"] == "host"
@@ -52,6 +59,8 @@ def test_hysteria2_parse():
     assert proxy["password"] == "pass"
     assert proxy["peer"] == "example.com"
     assert proxy["insecure"] == "1"
+    assert proxy["upmbps"] == "10"
+    assert proxy["downmbps"] == "20"
 
 
 def test_hysteria2_invalid():
@@ -65,3 +74,33 @@ def test_tuic_parse():
     assert proxy["uuid"] == "uuid"
     assert proxy["password"] == "pw"
     assert proxy["alpn"] == "h3"
+
+
+def test_vless_parse_ws_headers():
+    headers = base64.urlsafe_b64encode(b'{"h": "v"}').decode().strip("=")
+    link = (
+        "vless://uuid@host:443?type=ws&host=ex.com&path=/a"
+        f"&ws-headers={headers}&serviceName=s"
+    )
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["network"] == "ws"
+    assert proxy["ws-headers"]["h"] == "v"
+    assert proxy["serviceName"] == "s"
+
+
+def test_trojan_parse_extra():
+    link = (
+        "trojan://pw@host:443?type=ws&host=example.com&path=/ws"
+        "&alpn=h2&flow=xtls-rprx-udp&serviceName=svc"
+        "&ws-headers="
+        + base64.urlsafe_b64encode(b'{"X-Test": "val"}').decode().strip("=")
+    )
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["type"] == "trojan"
+    assert proxy["network"] == "ws"
+    assert proxy["host"] == "example.com"
+    assert proxy["path"] == "/ws"
+    assert proxy["alpn"] == "h2"
+    assert proxy["flow"] == "xtls-rprx-udp"
+    assert proxy["serviceName"] == "svc"
+    assert proxy["ws-headers"]["X-Test"] == "val"

--- a/tests/test_vmess_parsing.py
+++ b/tests/test_vmess_parsing.py
@@ -55,3 +55,9 @@ def test_vmess_parse_options():
     assert proxy["sni"] == "ex.com"
     assert proxy["alpn"] == "h2"
     assert proxy["flow"] == "xtls-rprx-origin"
+
+
+def test_vmess_invalid_link():
+    proxy = config_to_clash_proxy("vmess://invalid", 0)
+    assert proxy["type"] == "vmess"
+    assert proxy["server"] == "invalid"


### PR DESCRIPTION
## Summary
- enrich `config_to_clash_proxy` docstring
- add support for ws headers, service names and more in vmess/vless/reality/trojan
- decode more SSR parameters such as udpport and uot
- parse additional fields for Hysteria2
- test new parsing features and malformed links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68735cc8354c8326a6a1476adc5b3bbb