### PR TITLE
Add seen_hashes lock with concurrency test

### DIFF
--- a/tests/test_merger_seen_hash_lock.py
+++ b/tests/test_merger_seen_hash_lock.py
@@ -1,0 +1,32 @@
+import asyncio
+import os
+import sys
+import pytest
+from aiohttp import web
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from vpn_merger import UltimateVPNMerger
+
+pytest_plugins = "aiohttp.pytest_plugin"
+
+
+@pytest.mark.asyncio
+async def test_merger_seen_hash_lock_prevents_duplicates(aiohttp_client):
+    async def handler(request):
+        return web.Response(text="vmess://abcdef0123456789abc")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    merger = UltimateVPNMerger()
+    merger.fetcher.session = client.session
+
+    r1, r2 = await asyncio.gather(
+        merger.fetcher.fetch_source(client.make_url("/")),
+        merger.fetcher.fetch_source(client.make_url("/")),
+    )
+
+    total = len(r1[1]) + len(r2[1])
+    assert total == 1
+    assert len(merger.seen_hashes) == 1


### PR DESCRIPTION
## Summary
- guard concurrent access to `seen_hashes` with `asyncio.Lock`
- use the lock while writing output files
- load resume files with locking
- test merger lock behaviour with concurrent fetches

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pydantic-settings`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873631fe6588326b67796e337dd89fc