### PR TITLE
Normalize URLs before hashing

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -73,6 +73,13 @@ def test_create_semantic_hash_query_param_order():
     assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
 
 
+def test_create_semantic_hash_duplicate_params_and_fragment():
+    proc = EnhancedConfigProcessor()
+    link1 = "foo://example.com/path?a=1&a=2&b=3#frag"
+    link2 = "foo://example.com/path?a=2&a=1&b=3"
+    assert proc.create_semantic_hash(link1) == proc.create_semantic_hash(link2)
+
+
 def test_create_semantic_hash_fragment_ignored_generic():
     proc = EnhancedConfigProcessor()
     link1 = "foo://example.com/path?a=1&b=2"


### PR DESCRIPTION
## Summary
- canonicalize URLs when parsing
- preserve JSON ordering for vmess/vless base64 data
- hash based on canonicalized URLs
- test hashing with duplicate params

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736322bd308326b5ee9c34a453e8bc