### PR TITLE
Use async DNS in GeoIP lookup

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import sys
@@ -235,7 +236,7 @@ def test_lookup_country(monkeypatch):
     monkeypatch.setitem(sys.modules, "geoip2", dummy_geoip2)
     monkeypatch.setitem(sys.modules, "geoip2.database", dummy_database)
 
-    assert proc.lookup_country("1.2.3.4") == "US"
+    assert asyncio.run(proc.lookup_country("1.2.3.4")) == "US"
 
 
 def test_deduplicate_semantic_equivalent(monkeypatch):


### PR DESCRIPTION
## Summary
- replace `socket.gethostbyname` with `asyncio.get_running_loop().getaddrinfo`
- await GeoIP lookup everywhere it's called
- update tests to call the async method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736b1cabd88326bb6ccee6704f6e7c