### PR TITLE
Remove max-concurrent flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ It also outputs a `clash.yaml` file that works in both Clash and Clash Meta.
   "output_dir": "output",
   "log_dir": "logs",
   "request_timeout": 10,
-  "max_concurrent": 20,
+  "concurrent_limit": 20,
   "write_base64": true,
   "write_singbox": true,
   "write_clash": true
@@ -744,7 +744,7 @@ Optional fields use these defaults when omitted:
 - `output_dir` – `output` (relative to this folder)
 - `log_dir` – `logs` (relative to this folder)
 - `request_timeout` – `10`
-- `max_concurrent` – `20`
+- `concurrent_limit` – `20`
 - `write_base64` – `true`
 - `write_singbox` – `true`
 - `write_clash` – `true`
@@ -754,7 +754,7 @@ Optional fields use these defaults when omitted:
 - **output_dir** – where merged files are created. May be any path.
 - **log_dir** – daily log files are written here. May be any path.
 - **request_timeout** – HTTP request timeout in seconds (override with `--request-timeout`).
-- **max_concurrent** – maximum simultaneous HTTP requests for validating and fetching sources (override with `--concurrent-limit`).
+- **concurrent_limit** – maximum simultaneous HTTP requests for validating and fetching sources (override with `--concurrent-limit`).
 - **write_base64** – create `merged_base64.txt` when `true`.
 - **write_singbox** – create `merged_singbox.json` when `true`.
 - **write_clash** – create `clash.yaml` when `true`.

--- a/config.json.example
+++ b/config.json.example
@@ -23,6 +23,6 @@
     "output_dir": "output",
     "log_dir": "logs",
     "request_timeout": 10,
-    "max_concurrent": 20,
+    "concurrent_limit": 20,
     "settings": {"retry_attempts": 3, "retry_base_delay": 1.0},
 }

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -671,11 +671,6 @@ def main() -> None:
         help="HTTP request timeout in seconds",
     )
     parser.add_argument(
-        "--max-concurrent",
-        type=int,
-        help=argparse.SUPPRESS,
-    )
-    parser.add_argument(
         "--failure-threshold",
         type=int,
         default=3,
@@ -703,8 +698,6 @@ def main() -> None:
         cfg.output_dir = args.output_dir
     if args.concurrent_limit is not None:
         cfg.concurrent_limit = args.concurrent_limit
-    elif args.max_concurrent is not None:
-        cfg.concurrent_limit = args.max_concurrent
     if args.request_timeout is not None:
         cfg.request_timeout = args.request_timeout
 


### PR DESCRIPTION
## Summary
- remove deprecated `--max-concurrent` CLI option
- update config example and README to document `concurrent_limit`
- cleanup CLI parsing fallback

## Testing
- `pip install -r requirements.txt`
- `pip install pydantic-settings`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736b2890f8832694f914b581e11d23