### PR TITLE
Add session_path setting

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -8,6 +8,7 @@ telegram_api_hash: YOUR_HASH
 telegram_bot_token: BOT_TOKEN
 allowed_user_ids:
   - 11111111
+session_path: user.session
 
 # Aggregator options
 protocols:

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -356,7 +356,9 @@ async def scrape_telegram_configs(
         return set()
 
     since = datetime.utcnow() - timedelta(hours=last_hours)
-    client = TelegramClient("user", cfg.telegram_api_id, cfg.telegram_api_hash)
+    client = TelegramClient(
+        cfg.session_path, cfg.telegram_api_id, cfg.telegram_api_hash
+    )
     configs: Set[str] = set()
 
     try:
@@ -579,9 +581,9 @@ async def telegram_bot_mode(
 
     bot = cast(
         TelegramClient,
-        TelegramClient("bot", cfg.telegram_api_id, cfg.telegram_api_hash).start(
-            bot_token=cfg.telegram_bot_token
-        ),
+        TelegramClient(
+            cfg.session_path, cfg.telegram_api_id, cfg.telegram_api_hash
+        ).start(bot_token=cfg.telegram_bot_token),
     )
     last_update = None
 

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     telegram_api_hash: Optional[str] = None
     telegram_bot_token: Optional[str] = None
     allowed_user_ids: List[int] = []
+    session_path: str = "user.session"
 
     protocols: List[str] = []
     exclude_patterns: List[str] = []

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -23,6 +23,7 @@ def test_load_defaults(tmp_path):
     assert loaded.concurrent_limit == 20
     assert loaded.retry_attempts == 3
     assert loaded.retry_base_delay == 1.0
+    assert loaded.session_path == "user.session"
 
 
 def test_load_invalid_json(tmp_path):
@@ -162,6 +163,7 @@ def test_env_override_generic_fields(tmp_path, monkeypatch):
     monkeypatch.setenv("WRITE_CLASH", "false")
     monkeypatch.setenv("PROTOCOLS", '["ss","ssr"]')
     monkeypatch.setenv("HEADERS", '{"X":"1"}')
+    monkeypatch.setenv("SESSION_PATH", "foo.session")
 
     loaded = load_config(p)
 
@@ -171,3 +173,4 @@ def test_env_override_generic_fields(tmp_path, monkeypatch):
     assert loaded.write_clash is False
     assert loaded.protocols == ["ss", "ssr"]
     assert loaded.headers == {"X": "1"}
+    assert loaded.session_path == "foo.session"


### PR DESCRIPTION
## Summary
- support custom session path for TelegramClient
- update `config.yaml.example`
- test session_path defaults and env override

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737f0c19288326b1685da6c8d71b64