### PR TITLE
Load pytest-asyncio for asyncio tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ nest-asyncio
 # Optional/feature dependencies
 telethon
 pytest
+pytest-asyncio
 PyYAML
 geoip2
 types-PyYAML

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     asyncio: mark test as asyncio
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-pytest_plugins = ['aiohttp.pytest_plugin']
+pytest_plugins = ["pytest_asyncio", 'aiohttp.pytest_plugin']
 
 import asyncio
 import pytest


### PR DESCRIPTION
## Summary
- add pytest-asyncio to dev requirements
- load pytest-asyncio in tests
- enable auto asyncio mode in pytest config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68737f0f356c8326b5b9c8a4de4cb2b7