### PR TITLE
Add daily update workflow

### DIFF
--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -1,0 +1,28 @@
+name: Daily Update
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run aggregator tool
+        run: python src/massconfigmerger/aggregator_tool.py --with-merger --hours 24
+      - name: Set timestamp
+        id: timestamp
+        run: echo "time=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_OUTPUT"
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update aggregated configs ${{ steps.timestamp.outputs.time }}"
+          file_pattern: output/**


### PR DESCRIPTION
## Summary
- run aggregator tool every six hours
- auto-commit output directory on new configs

## Testing
- `pytest -q` *(fails: Timeout context manager should be used inside a task)*

------
https://chatgpt.com/codex/tasks/task_e_6873e85f6cf483268f8b8825e51b9ee8