### PR TITLE
Add Surge and QX config exporters

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -107,6 +107,8 @@ strict_batch: true
 shuffle_sources: false
 write_csv: true
 write_clash_proxies: true
+write_surge: false
+write_qx: false
 mux_concurrency: 8
 smux_streams: 4
 geoip_db: null

--- a/src/massconfigmerger/advanced_converters.py
+++ b/src/massconfigmerger/advanced_converters.py
@@ -1,0 +1,80 @@
+"""Utility converters for additional client formats."""
+
+from typing import Any, Dict, List
+
+
+def generate_surge_conf(proxies: List[Dict[str, Any]]) -> str:
+    """Return a Surge `[Proxy]` configuration block for ``proxies``.
+
+    Each proxy dictionary should follow the Clash format produced by
+    :func:`massconfigmerger.clash_utils.config_to_clash_proxy`.
+    Only common options are included to keep the output broadly
+    compatible with modern Surge versions.
+    """
+    lines = ["[Proxy]"]
+    for p in proxies:
+        name = p.get("name", "proxy")
+        typ = p.get("type", "http")
+        server = p.get("server", "")
+        port = p.get("port", 0)
+        line = f"{name} = {typ}, {server}, {port}"
+        if p.get("uuid"):
+            line += f", username={p['uuid']}"
+        if p.get("password") and typ != "ss":
+            line += f", password={p['password']}"
+        if p.get("cipher") and typ == "ss":
+            line += f", encrypt-method={p['cipher']}"
+            if p.get("password"):
+                line += f", password={p['password']}"
+        if p.get("tls"):
+            line += ", tls=true"
+        if p.get("sni"):
+            line += f", sni={p['sni']}"
+        net = p.get("network")
+        if net == "ws":
+            line += ", ws=true"
+            if p.get("path"):
+                line += f", ws-path={p['path']}"
+            if p.get("host"):
+                line += f", ws-headers=Host:{p['host']}"
+        if net == "grpc":
+            line += ", grpc=true"
+            if p.get("serviceName"):
+                line += f", grpc-service-name={p['serviceName']}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def generate_qx_conf(proxies: List[Dict[str, Any]]) -> str:
+    """Return Quantumult X server lines for ``proxies``."""
+    lines = []
+    for p in proxies:
+        typ = p.get("type", "http")
+        server = p.get("server", "")
+        port = p.get("port", 0)
+        base = f"{typ}={server}:{port}"
+        params = []
+        if p.get("uuid"):
+            params.append(f"id={p['uuid']}")
+        if p.get("password"):
+            params.append(f"password={p['password']}")
+        if p.get("cipher"):
+            params.append(f"method={p['cipher']}")
+        if p.get("tls"):
+            params.append("tls=true")
+        if p.get("sni"):
+            params.append(f"tls-host={p['sni']}")
+        net = p.get("network")
+        if net == "ws":
+            params.append("obfs=ws")
+            if p.get("host"):
+                params.append(f"obfs-host={p['host']}")
+            if p.get("path"):
+                params.append(f"obfs-uri={p['path']}")
+        if net == "grpc":
+            params.append("obfs=grpc")
+            if p.get("serviceName"):
+                params.append(f"grpc-service-name={p['serviceName']}")
+        params.append(f"tag={p.get('name', 'proxy')}")
+        lines.append(base + ", " + ", ".join(params))
+    return "\n".join(lines)

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -115,6 +115,8 @@ class Settings(BaseSettings):
     shuffle_sources: bool = False
     write_csv: bool = True
     write_clash_proxies: bool = True
+    write_surge: bool = False
+    write_qx: bool = False
     mux_concurrency: int = 8
     smux_streams: int = 4
     geoip_db: Optional[str] = None


### PR DESCRIPTION
## Summary
- implement new advanced_converters module with Surge/QX generators
- expose write_surge and write_qx settings
- add CLI flags `--output-surge` and `--output-qx`
- generate Surge/QX config files when requested
- avoid nest_asyncio patch during import

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q` *(fails: RuntimeError: Timeout context manager should be used inside a task)*

------
https://chatgpt.com/codex/tasks/task_e_6873e866ff348326aa139a2fe064a21e