### PR TITLE
Update dependency separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ Install the `geoip2` package and download the free GeoLite2 database from MaxMin
 Run `pytest` to execute the test suite. Install dependencies first with:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt -r dev-requirements.txt
 pip install -e .  # or export PYTHONPATH=$PWD
 ```
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,6 @@
-# Core runtime dependencies
-aiohttp
-aiodns
-nest-asyncio
-
-# Optional/feature dependencies
-telethon
+# Test and development dependencies
 pytest
 pytest-asyncio
-PyYAML
-geoip2
 types-PyYAML
 types-requests
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ nest-asyncio
 telethon
 PyYAML
 geoip2
+pydantic
+pydantic-settings


### PR DESCRIPTION
## Summary
- keep runtime deps in `requirements.txt`
- move dev-only deps to `dev-requirements.txt`
- document installing both files for running tests
- include `pydantic` and `pydantic-settings` in runtime requirements

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q` *(fails: Timeout context manager should be used inside a task)*

------
https://chatgpt.com/codex/tasks/task_e_6873ea8b5b148326aa3c7402b7879bca