### PR TITLE
Improve Reality parsing and update TUIC/Hysteria2 tests

### DIFF
--- a/src/massconfigmerger/clash_utils.py
+++ b/src/massconfigmerger/clash_utils.py
@@ -27,7 +27,8 @@ def config_to_clash_proxy(
         ``fp``, ``flow``, ``serviceName`` and ``ws-headers``.
     ``vless``/``reality``
         ``encryption``, ``network``, ``host``, ``path``, ``sni``, ``alpn``,
-        ``fp``, ``flow``, ``pbk``, ``sid``, ``serviceName`` and ``ws-headers``.
+        ``fp``, ``flow``, ``pbk``, ``sid``, ``serviceName``, ``ws-headers`` and
+        ``reality-opts``.
     ``trojan``
         ``network`` (``ws``/``grpc``), ``host``, ``path``, ``sni``, ``alpn``,
         ``flow``, ``serviceName`` and ``ws-headers``.
@@ -165,9 +166,15 @@ def config_to_clash_proxy(
                 "encryption": q.get("encryption", ["none"])[0],
                 "tls": True,
             }
-            for key in ("sni", "alpn", "fp", "pbk", "sid", "serviceName"):
+            for key in ("sni", "alpn", "fp", "serviceName"):
                 if key in q:
                     proxy[key] = q[key][0]
+            pbk = q.get("pbk") or q.get("public-key") or q.get("publicKey")
+            sid = q.get("sid") or q.get("short-id") or q.get("shortId")
+            if pbk:
+                proxy["pbk"] = pbk[0]
+            if sid:
+                proxy["sid"] = sid[0]
             if "ws-headers" in q:
                 try:
                     padded = q["ws-headers"][0] + "=" * (-len(q["ws-headers"][0]) % 4)
@@ -177,6 +184,13 @@ def config_to_clash_proxy(
             flows = q.get("flow")
             if flows:
                 proxy["flow"] = flows[0]
+            reality_opts = {}
+            if pbk:
+                reality_opts["public-key"] = pbk[0]
+            if sid:
+                reality_opts["short-id"] = sid[0]
+            if reality_opts:
+                proxy["reality-opts"] = reality_opts
             net = q.get("type") or q.get("mode")
             if net:
                 proxy["network"] = net[0]

--- a/tests/test_clash_parsing_extra.py
+++ b/tests/test_clash_parsing_extra.py
@@ -42,6 +42,8 @@ def test_reality_parse_extra():
     assert proxy["flow"] == "xtls-rprx-vision"
     assert proxy["pbk"] == "pub"
     assert proxy["sid"] == "123"
+    assert proxy["reality-opts"]["public-key"] == "pub"
+    assert proxy["reality-opts"]["short-id"] == "123"
     assert proxy["sni"] == "example.com"
     assert proxy["fp"] == "chrome"
     assert proxy["name"] == "test"

--- a/tests/test_clash_proxies_yaml.py
+++ b/tests/test_clash_proxies_yaml.py
@@ -37,7 +37,7 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
         source_url="s",
     )
     res4 = ConfigResult(
-        config="reality://uuid@host:443?flow=xtls-rprx-vision",
+        config="reality://uuid@host:443?flow=xtls-rprx-vision&pbk=pub&sid=123",
         protocol="Reality",
         host="host",
         port=443,
@@ -45,14 +45,38 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
         is_reachable=True,
         source_url="s",
     )
-    results = [res1, res2, res3, res4]
+    res5 = ConfigResult(
+        config=(
+            "tuic://uuid:pw@host:10443?alpn=h3&congestion-control=bbr"
+            "&udp-relay-mode=native"
+        ),
+        protocol="TUIC",
+        host="host",
+        port=10443,
+        ping_time=0.5,
+        is_reachable=True,
+        source_url="s",
+    )
+    res6 = ConfigResult(
+        config=(
+            "hy2://pass@host:8443?peer=example.com&insecure=1&obfs=obfs"
+            "&obfs-password=secret"
+        ),
+        protocol="Hysteria2",
+        host="host",
+        port=8443,
+        ping_time=0.6,
+        is_reachable=True,
+        source_url="s",
+    )
+    results = [res1, res2, res3, res4, res5, res6]
     stats = merger._analyze_results(results, [])
     asyncio.run(merger._generate_comprehensive_outputs(results, stats, 0.0))
     path = tmp_path / "vpn_clash_proxies.yaml"
     assert path.exists()
     data = yaml.safe_load(path.read_text())
     assert "proxies" in data
-    assert len(data["proxies"]) == 4
+    assert len(data["proxies"]) == 6
     naive = next(p for p in data["proxies"] if p["type"] == "http")
     assert naive["username"] == "user"
     assert naive["password"] == "pass"
@@ -60,3 +84,26 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     reality = next(p for p in data["proxies"] if p.get("flow"))
     assert reality["type"] == "vless"
     assert reality["tls"] is True
+    assert reality["reality-opts"]["public-key"] == "pub"
+    assert reality["reality-opts"]["short-id"] == "123"
+
+    tuic = next(p for p in data["proxies"] if p["type"] == "tuic")
+    assert tuic["uuid"] == "uuid"
+    assert tuic["password"] == "pw"
+    assert tuic["alpn"] == "h3"
+    assert tuic["congestion-control"] == "bbr"
+    assert tuic["udp-relay-mode"] == "native"
+
+    hy2 = next(p for p in data["proxies"] if p["type"] == "hysteria2")
+    assert hy2["password"] == "pass"
+    assert hy2["peer"] == "example.com"
+    assert hy2["insecure"] == "1"
+    assert hy2["obfs"] == "obfs"
+    assert hy2["obfs_password"] == "secret"
+
+    singbox = tmp_path / "vpn_singbox.json"
+    assert singbox.exists()
+    import json
+    sdata = json.loads(singbox.read_text())
+    types = [ob["type"] for ob in sdata.get("outbounds", [])]
+    assert "tuic" in types and "hysteria2" in types


### PR DESCRIPTION
## Summary
- extract pbk and sid more flexibly in `config_to_clash_proxy`
- output `reality-opts` with parsed pbk and sid
- check new reality options in tests
- verify TUIC v5 and Hysteria2 mapping for Clash and Sing-box outputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ed65f31883269d5cc6b6bfeb61d3