### PR TITLE
Implement proxy reliability tracking

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -114,3 +114,5 @@ smux_streams: 4
 geoip_db: null
 include_countries: null
 exclude_countries: null
+history_file: proxy_history.json
+sort_by: latency

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -162,6 +162,9 @@ async def fetch_text(
         return None
 
     attempt = 0
+    use_temp = hasattr(session, "loop") and session.loop is not asyncio.get_running_loop()
+    if use_temp:
+        session = aiohttp.ClientSession()
     while attempt < retries:
         try:
             async with session.get(url, timeout=ClientTimeout(total=timeout)) as resp:
@@ -185,6 +188,8 @@ async def fetch_text(
             break
         delay = base_delay * 2 ** (attempt - 1)
         await asyncio.sleep(delay + random.uniform(0, jitter))
+    if use_temp:
+        await session.close()
     return None
 
 

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -122,6 +122,8 @@ class Settings(BaseSettings):
     geoip_db: Optional[str] = None
     include_countries: Optional[Set[str]] = None
     exclude_countries: Optional[Set[str]] = None
+    history_file: str = "proxy_history.json"
+    sort_by: str = "latency"
 
     model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
 

--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -149,6 +149,25 @@ def test_sort_by_performance():
     assert ordered[-1] == r4
 
 
+def test_sort_by_reliability(monkeypatch):
+    monkeypatch.setattr(CONFIG, "sort_by", "reliability")
+    merger = UltimateVPNMerger()
+    r1 = ConfigResult(config="a", protocol="VMess", ping_time=0.5, is_reachable=True)
+    r2 = ConfigResult(config="b", protocol="VMess", ping_time=0.2, is_reachable=True)
+    r3 = ConfigResult(config="c", protocol="VMess", ping_time=0.1, is_reachable=True)
+
+    h1 = merger.processor.create_semantic_hash("a")
+    h2 = merger.processor.create_semantic_hash("b")
+    merger.proxy_history = {
+        h1: {"successful_checks": 1, "total_checks": 2},
+        h2: {"successful_checks": 1, "total_checks": 5},
+    }
+
+    ordered = merger._sort_by_performance([r1, r2, r3])
+    assert ordered[0] == r1
+    assert ordered[1] == r2
+
+
 def test_deduplicate_config_results(monkeypatch):
     merger = UltimateVPNMerger()
     monkeypatch.setattr(CONFIG, "tls_fragment", None)

--- a/tests/test_proxy_history.py
+++ b/tests/test_proxy_history.py
@@ -1,0 +1,14 @@
+import asyncio
+import json
+from massconfigmerger.vpn_merger import UltimateVPNMerger, CONFIG
+
+
+def test_proxy_history_update(tmp_path, monkeypatch):
+    monkeypatch.setattr(CONFIG, "output_dir", str(tmp_path))
+    merger = UltimateVPNMerger()
+    h = merger.processor.create_semantic_hash("vmess://id@h:80")
+    asyncio.run(merger._update_history(h, True))
+    asyncio.run(merger._save_proxy_history())
+    data = json.loads((tmp_path / CONFIG.history_file).read_text())
+    assert data[h]["successful_checks"] == 1
+    assert data[h]["total_checks"] == 1


### PR DESCRIPTION
## Summary
- maintain output/proxy_history.json for persistent reliability data
- track `successful_checks` and `total_checks` for each proxy
- add `--sort-by reliability` to prioritize history stats when sorting
- load and save proxy history in merger runs
- update aggregator and tests for new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-asyncio pytest-aiohttp`
- `pip install -q -r dev-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873ec0d69988326ab61c0e5fd58b83d