### PR TITLE
Add progress display and proxy enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ environment variable in `docker-compose.yml` to change how often it runs.
 | **Logging to File** | Save all output to a file with `--log-file`. | Useful for headless servers or debugging. |
 | **Standalone or Cumulative Batches** | Use `--cumulative-batches` to keep growing files, otherwise each batch only contains new configs. | Flexible automation for heavy runs. |
 | **Strict Split** | Batches are strictly capped at `--batch-size` by default. Add `--no-strict-batch` to simply trigger on size. | Control how incremental files are produced. |
-| **Shuffle Sources** | `--shuffle-sources` randomizes the source order. | Helpful when using `--threshold` to avoid bias. |
+| **Shuffle Sources** | `--shuffle-sources` randomizes the source order. | Helpful when using `--stop-after-found` to avoid bias. |
 | **Sing-box JSON Output** | Every batch also produces `vpn_singbox.json`. | Import directly into modern clients like sing-box/Stash. |
 | **Clash YAML Output** | Generate `clash.yaml` (or `batch_*clash.yaml`) for Clash/Clash Meta users. | Works with any client supporting Clash configs. |
 | **Hiddify Optimised** | Default protocols match the Hiddify client. | Other clients may reject some entries. |
@@ -571,7 +571,7 @@ During long runs, files prefixed with `cumulative_` mirror the latest results an
 Run `python vpn_merger.py --help` to see all options. Important flags include:
 
   * `--batch-size N` - save intermediate files every `N` configs (default `100`, `0` to disable).
-  * `--threshold N` - stop once `N` unique configs are collected.
+  * `--stop-after-found N` - stop once `N` unique configs are collected.
   * `--no-url-test` - skip reachability testing for faster execution.
   * `--no-sort` - keep configs in the order retrieved without sorting.
   * `--top-n N` - keep only the best `N` configs after sorting.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ PyYAML
 geoip2
 pydantic
 pydantic-settings
+tqdm
+colorama

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Iterable, List, Set, Optional, Dict, Union, Tuple, cast
 from urllib.parse import urlparse
-from .clash_utils import config_to_clash_proxy
+from .clash_utils import config_to_clash_proxy, build_clash_config
 
 import yaml
 
@@ -491,16 +491,7 @@ def output_files(configs: List[str], out_dir: Path, cfg: Settings) -> List[Path]
             if proxy:
                 proxies.append(proxy)
         if proxies:
-            group = {
-                "name": "Proxy",
-                "type": "select",
-                "proxies": [p["name"] for p in proxies],
-            }
-            clash_yaml = yaml.safe_dump(
-                {"proxies": proxies, "proxy-groups": [group]},
-                allow_unicode=True,
-                sort_keys=False,
-            )
+            clash_yaml = build_clash_config(proxies)
             clash_file = out_dir / "clash.yaml"
             clash_file.write_text(clash_yaml)
             written.append(clash_file)

--- a/src/massconfigmerger/clash_utils.py
+++ b/src/massconfigmerger/clash_utils.py
@@ -5,7 +5,9 @@ import binascii
 import json
 import logging
 from urllib.parse import parse_qs, urlparse
-from typing import Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
+
+import yaml
 
 
 def config_to_clash_proxy(
@@ -384,3 +386,35 @@ def config_to_clash_proxy(
     ) as exc:
         logging.debug("config_to_clash_proxy failed: %s", exc)
         return None
+
+
+def flag_emoji(country: Optional[str]) -> str:
+    """Return flag emoji for a 2-letter country code."""
+    if not country or len(country) != 2:
+        return "🏳"
+    offset = 127397
+    return chr(ord(country[0].upper()) + offset) + chr(ord(country[1].upper()) + offset)
+
+
+def build_clash_config(proxies: List[Dict[str, Any]]) -> str:
+    """Return a Clash YAML config with default groups and rule."""
+    if not proxies:
+        return ""
+
+    names = [p["name"] for p in proxies]
+    groups = [
+        {
+            "name": "⚡ Auto-Select",
+            "type": "url-test",
+            "proxies": names,
+            "url": "http://www.gstatic.com/generate_204",
+            "interval": 300,
+        },
+        {"name": "🔰 MANUAL", "type": "select", "proxies": names},
+    ]
+    rules = ["MATCH, ⚡ Auto-Select"]
+    return yaml.safe_dump(
+        {"proxies": proxies, "proxy-groups": groups, "rules": rules},
+        allow_unicode=True,
+        sort_keys=False,
+    )

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -45,7 +45,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 from .constants import SOURCES_FILE
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse, parse_qsl
-from .clash_utils import config_to_clash_proxy
+from .clash_utils import config_to_clash_proxy, flag_emoji, build_clash_config
 
 from .config import Settings, load_config
 
@@ -1113,16 +1113,18 @@ class UltimateVPNMerger:
         proxies = []
         for idx, r in enumerate(results):
             proxy = config_to_clash_proxy(r.config, idx, r.protocol)
-            if proxy:
-                proxies.append(proxy)
-        if not proxies:
-            return ""
-        group = {
-            "name": "Auto",
-            "type": "select",
-            "proxies": [p["name"] for p in proxies],
-        }
-        return yaml.safe_dump({"proxies": proxies, "proxy-groups": [group]}, allow_unicode=True, sort_keys=False)
+            if not proxy:
+                continue
+            latency = (
+                f"{int(r.ping_time * 1000)}ms" if r.ping_time is not None else "?"
+            )
+            domain = urlparse(r.source_url).hostname or "src"
+            cc = r.country or "??"
+            emoji = flag_emoji(r.country)
+            proxy["name"] = f"{emoji} {cc} - {domain} - {latency}"
+            proxies.append(proxy)
+
+        return build_clash_config(proxies)
     
     def _print_final_summary(self, config_count: int, elapsed_time: float, stats: Dict) -> None:
         """Print comprehensive final summary."""
@@ -1136,25 +1138,28 @@ class UltimateVPNMerger:
         else:
             success = "N/A"
         print(f"📈 Success rate: {success}")
-        print(f"🔗 Available sources: {stats['available_sources']}/{stats['total_sources']}")
         speed = (config_count / elapsed_time) if elapsed_time else 0
-        print(f"⚡ Processing speed: {speed:.0f} configs/second")
-        
+
+        rows = [
+            ("Total configs", f"{config_count:,}"),
+            ("Reachable", f"{stats['reachable_configs']:,}"),
+            ("Success rate", success),
+            ("Sources", f"{stats['available_sources']}/{stats['total_sources']}"),
+            ("Speed", f"{speed:.0f} cfg/s"),
+        ]
+        print("\033[95m\nSUMMARY\033[0m")
+        print("\033[94m┌────────────────────┬──────────────┐\033[0m")
+        for label, value in rows:
+            print(f"\033[94m│ {label:<18} │\033[92m {value:<12}\033[94m│\033[0m")
+        print("\033[94m└────────────────────┴──────────────┘\033[0m")
         if CONFIG.enable_sorting and stats['reachable_configs'] > 0:
             print("🚀 Configs sorted by performance (fastest first)")
-        
         if stats['protocol_stats']:
             top_protocol = max(stats['protocol_stats'].items(), key=lambda x: x[1])[0]
         else:
             top_protocol = "N/A"
         print(f"🏆 Top protocol: {top_protocol}")
         print(f"📁 Output directory: ./{CONFIG.output_dir}/")
-        print("\n🔗 Usage Instructions:")
-        print("   • Copy Base64 file content as subscription URL")
-        print("   • Use CSV file for detailed analysis and filtering")
-        print("   • All configs tested and sorted by performance")
-        print("   • Dead sources automatically removed")
-        print("=" * 85)
 
 # ============================================================================
 # EVENT LOOP DETECTION AND MAIN EXECUTION
@@ -1230,8 +1235,13 @@ def main():
         default=CONFIG.batch_size,
         help="Save intermediate output every N configs (0 disables, default 100)"
     )
-    parser.add_argument("--threshold", type=int, default=CONFIG.threshold,
-                        help="Stop processing after N unique configs (0 = unlimited)")
+    parser.add_argument(
+        "--stop-after-found",
+        type=int,
+        default=CONFIG.threshold,
+        help="Stop processing after N unique configs (0 = unlimited)",
+        dest="threshold",
+    )
     parser.add_argument("--top-n", type=int, default=CONFIG.top_n,
                         help="Keep only the N best configs after sorting (0 = all)")
     parser.add_argument("--tls-fragment", type=str, default=CONFIG.tls_fragment,

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -9,6 +9,8 @@ import csv
 from pathlib import Path
 from typing import List, Tuple, Optional
 
+from tqdm.asyncio import tqdm_asyncio
+
 from .vpn_merger import EnhancedConfigProcessor, CONFIG
 
 
@@ -30,7 +32,7 @@ async def retest_configs(configs: List[str]) -> List[Tuple[str, Optional[float]]
             return await _test_config(proc, cfg)
 
     tasks = [asyncio.create_task(worker(c)) for c in configs]
-    return await asyncio.gather(*tasks)
+    return await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Testing")
 
 
 def load_configs(path: Path) -> List[str]:


### PR DESCRIPTION
## Summary
- rename `--threshold` flag to `--stop-after-found`
- integrate tqdm in vpn_retester for progress display
- create helpers for clash configs and proxy naming
- generate auto and manual groups in clash yaml outputs
- show colored summary table when vpn_merger finishes
- document updated flag

## Testing
- `pip install -r requirements.txt`
- `pip install -r dev-requirements.txt`
- `pytest -q` *(fails: RuntimeError: Timeout context manager should be used inside a task)*

------
https://chatgpt.com/codex/tasks/task_e_6873ec183c988326821020285d8e22a8