### PR TITLE
Add proxy settings and pre-check

### DIFF
--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -122,6 +122,8 @@ class Settings(BaseSettings):
     geoip_db: Optional[str] = None
     include_countries: Optional[Set[str]] = None
     exclude_countries: Optional[Set[str]] = None
+    http_proxy: Optional[str] = None
+    socks_proxy: Optional[str] = None
 
     model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
 

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -729,7 +729,11 @@ class UltimateVPNMerger:
             resolver=AsyncResolver()
         )
         
-        self.fetcher.session = aiohttp.ClientSession(connector=connector)
+        proxy = CONFIG.http_proxy or CONFIG.socks_proxy
+        self.fetcher.session = aiohttp.ClientSession(
+            connector=connector,
+            proxy=proxy,
+        )
         
         try:
             # Test all sources concurrently

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 pytest_plugins = ["pytest_asyncio", 'aiohttp.pytest_plugin']
 
 import asyncio
+import os
 import pytest
 
 @pytest.fixture
@@ -12,3 +13,16 @@ def loop():
 @pytest.fixture
 def event_loop(loop):
     yield loop
+
+
+@pytest.fixture(autouse=True)
+def clear_proxy_env(monkeypatch):
+    for var in ["HTTP_PROXY", "http_proxy", "SOCKS_PROXY", "socks_proxy"]:
+        monkeypatch.delenv(var, raising=False)
+    try:
+        from massconfigmerger.vpn_merger import CONFIG
+        CONFIG.http_proxy = None
+        CONFIG.socks_proxy = None
+        print("clear_proxy_env applied")
+    except Exception:
+        pass

--- a/tests/test_config_load.py
+++ b/tests/test_config_load.py
@@ -174,3 +174,21 @@ def test_env_override_generic_fields(tmp_path, monkeypatch):
     assert loaded.protocols == ["ss", "ssr"]
     assert loaded.headers == {"X": "1"}
     assert loaded.session_path == "foo.session"
+
+
+def test_proxy_defaults(tmp_path):
+    p = tmp_path / "cfg.yaml"
+    p.write_text("{}")
+    cfg = load_config(p)
+    assert cfg.http_proxy is None
+    assert cfg.socks_proxy is None
+
+
+def test_proxy_env_override(tmp_path, monkeypatch):
+    p = tmp_path / "cfg.yaml"
+    p.write_text("{}")
+    monkeypatch.setenv("HTTP_PROXY", "http://localhost:8080")
+    monkeypatch.setenv("SOCKS_PROXY", "socks5://localhost:1080")
+    cfg = load_config(p)
+    assert cfg.http_proxy == "http://localhost:8080"
+    assert cfg.socks_proxy == "socks5://localhost:1080"


### PR DESCRIPTION
## Summary
- add HTTP and SOCKS proxy configuration options
- use these proxies when creating the aiohttp session
- clear proxy env vars during tests
- test loading proxy values from config

## Testing
- `pytest tests/test_config_load.py::test_proxy_defaults tests/test_config_load.py::test_proxy_env_override -q`
- `pytest -q` *(fails: RuntimeError: Timeout context manager should be used inside a task)*

------
https://chatgpt.com/codex/tasks/task_e_6873ed69e0508326a3d9658931d55108