### PR TITLE
Add latency tracking to proxy history

### DIFF
--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -168,6 +168,25 @@ def test_sort_by_reliability(monkeypatch):
     assert ordered[1] == r2
 
 
+def test_sort_by_reliability_latency_tiebreak(monkeypatch):
+    monkeypatch.setattr(CONFIG, "sort_by", "reliability")
+    merger = UltimateVPNMerger()
+    r1 = ConfigResult(config="a", protocol="VMess", ping_time=0.2, is_reachable=True)
+    r2 = ConfigResult(config="b", protocol="VMess", ping_time=0.3, is_reachable=True)
+
+    h1 = merger.processor.create_semantic_hash("a")
+    h2 = merger.processor.create_semantic_hash("b")
+    # equal reliability -> order by latency
+    merger.proxy_history = {
+        h1: {"successful_checks": 1, "total_checks": 2},
+        h2: {"successful_checks": 1, "total_checks": 2},
+    }
+
+    ordered = merger._sort_by_performance([r2, r1])
+    assert ordered[0] == r1
+    assert ordered[1] == r2
+
+
 def test_deduplicate_config_results(monkeypatch):
     merger = UltimateVPNMerger()
     monkeypatch.setattr(CONFIG, "tls_fragment", None)

--- a/tests/test_proxy_history.py
+++ b/tests/test_proxy_history.py
@@ -7,8 +7,9 @@ def test_proxy_history_update(tmp_path, monkeypatch):
     monkeypatch.setattr(CONFIG, "output_dir", str(tmp_path))
     merger = UltimateVPNMerger()
     h = merger.processor.create_semantic_hash("vmess://id@h:80")
-    asyncio.run(merger._update_history(h, True))
+    asyncio.run(merger._update_history(h, True, 0.123))
     asyncio.run(merger._save_proxy_history())
     data = json.loads((tmp_path / CONFIG.history_file).read_text())
     assert data[h]["successful_checks"] == 1
     assert data[h]["total_checks"] == 1
+    assert data[h]["latency_ms"] == 123.0


### PR DESCRIPTION
## Summary
- store latest latency in proxy history
- include latency when updating history
- sort-by reliability ties now resolved by latency
- test proxy history latency and reliability tie breaking

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f5dce7b08326b098a02bfe3ef307