### PR TITLE
Add Surge & QX output generators

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -107,8 +107,8 @@ strict_batch: true
 shuffle_sources: false
 write_csv: true
 write_clash_proxies: true
-write_surge: false
-write_qx: false
+surge_file: null
+qx_file: null
 mux_concurrency: 8
 smux_streams: 4
 geoip_db: null

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -115,8 +115,8 @@ class Settings(BaseSettings):
     shuffle_sources: bool = False
     write_csv: bool = True
     write_clash_proxies: bool = True
-    write_surge: bool = False
-    write_qx: bool = False
+    surge_file: Optional[str] = None
+    qx_file: Optional[str] = None
     mux_concurrency: int = 8
     smux_streams: int = 4
     geoip_db: Optional[str] = None

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -1201,7 +1201,7 @@ class UltimateVPNMerger:
                 tmp_clash.write_text(clash_yaml, encoding="utf-8")
                 tmp_clash.replace(clash_file)
 
-            need_proxies = CONFIG.write_clash_proxies or CONFIG.write_surge or CONFIG.write_qx
+            need_proxies = CONFIG.write_clash_proxies or CONFIG.surge_file or CONFIG.qx_file
             proxies: List[Dict[str, Any]] = []
             if need_proxies:
                 for idx, r in enumerate(results):
@@ -1216,18 +1216,22 @@ class UltimateVPNMerger:
                 tmp_proxies.write_text(proxy_yaml, encoding="utf-8")
                 tmp_proxies.replace(proxies_file)
 
-            if CONFIG.write_surge:
+            if CONFIG.surge_file:
                 from .advanced_converters import generate_surge_conf
                 surge_content = generate_surge_conf(proxies)
-                surge_file = output_dir / f"{prefix}surge.conf"
+                surge_file = Path(CONFIG.surge_file)
+                if not surge_file.is_absolute():
+                    surge_file = output_dir / surge_file
                 tmp_surge = surge_file.with_suffix('.tmp')
                 tmp_surge.write_text(surge_content, encoding="utf-8")
                 tmp_surge.replace(surge_file)
 
-            if CONFIG.write_qx:
+            if CONFIG.qx_file:
                 from .advanced_converters import generate_qx_conf
                 qx_content = generate_qx_conf(proxies)
-                qx_file = output_dir / f"{prefix}qx.conf"
+                qx_file = Path(CONFIG.qx_file)
+                if not qx_file.is_absolute():
+                    qx_file = output_dir / qx_file
                 tmp_qx = qx_file.with_suffix('.tmp')
                 tmp_qx.write_text(qx_content, encoding="utf-8")
                 tmp_qx.replace(qx_file)
@@ -1424,10 +1428,20 @@ def main():
                         help="Do not save CSV report")
     parser.add_argument("--no-proxy-yaml", action="store_true",
                         help="Do not save simple Clash proxy list")
-    parser.add_argument("--output-surge", action="store_true",
-                        help="Write Surge formatted proxy list")
-    parser.add_argument("--output-qx", action="store_true",
-                        help="Write Quantumult X formatted proxy list")
+    parser.add_argument(
+        "--output-surge",
+        metavar="FILE",
+        type=str,
+        default=None,
+        help="Write Surge formatted proxy list to FILE",
+    )
+    parser.add_argument(
+        "--output-qx",
+        metavar="FILE",
+        type=str,
+        default=None,
+        help="Write Quantumult X formatted proxy list to FILE",
+    )
     parser.add_argument("--geoip-db", type=str, default=None,
                         help="Path to GeoLite2 Country database for GeoIP lookup")
     parser.add_argument(
@@ -1479,8 +1493,8 @@ def main():
     CONFIG.write_base64 = not args.no_base64
     CONFIG.write_csv = not args.no_csv
     CONFIG.write_clash_proxies = not args.no_proxy_yaml
-    CONFIG.write_surge = args.output_surge
-    CONFIG.write_qx = args.output_qx
+    CONFIG.surge_file = args.output_surge
+    CONFIG.qx_file = args.output_qx
     CONFIG.cumulative_batches = args.cumulative_batches
     CONFIG.strict_batch = not args.no_strict_batch
     CONFIG.shuffle_sources = args.shuffle_sources

--- a/tests/test_advanced_converters.py
+++ b/tests/test_advanced_converters.py
@@ -1,0 +1,71 @@
+import textwrap
+from massconfigmerger.advanced_converters import generate_surge_conf, generate_qx_conf
+
+
+def test_generate_surge_conf():
+    proxies = [
+        {
+            "name": "ws",
+            "type": "vmess",
+            "server": "s.com",
+            "port": 443,
+            "uuid": "id",
+            "tls": True,
+            "network": "ws",
+            "host": "h",
+            "path": "/ws",
+        },
+        {
+            "name": "grpc",
+            "type": "vless",
+            "server": "g.com",
+            "port": 443,
+            "uuid": "id2",
+            "tls": True,
+            "network": "grpc",
+            "serviceName": "sn",
+        },
+    ]
+    conf = generate_surge_conf(proxies)
+    expected = textwrap.dedent(
+        """
+        [Proxy]
+        ws = vmess, s.com, 443, username=id, tls=true, ws=true, ws-path=/ws, ws-headers=Host:h
+        grpc = vless, g.com, 443, username=id2, tls=true, grpc=true, grpc-service-name=sn
+        """
+    ).strip()
+    assert conf == expected
+
+
+def test_generate_qx_conf():
+    proxies = [
+        {
+            "name": "ws",
+            "type": "vmess",
+            "server": "s.com",
+            "port": 443,
+            "uuid": "id",
+            "tls": True,
+            "network": "ws",
+            "host": "h",
+            "path": "/ws",
+        },
+        {
+            "name": "grpc",
+            "type": "vless",
+            "server": "g.com",
+            "port": 443,
+            "uuid": "id2",
+            "tls": True,
+            "network": "grpc",
+            "serviceName": "sn",
+        },
+    ]
+    conf = generate_qx_conf(proxies)
+    expected = textwrap.dedent(
+        """
+        vmess=s.com:443, id=id, tls=true, obfs=ws, obfs-host=h, obfs-uri=/ws, tag=ws
+        vless=g.com:443, id=id2, tls=true, obfs=grpc, grpc-service-name=sn, tag=grpc
+        """
+    ).strip()
+    assert conf == expected


### PR DESCRIPTION
## Summary
- support specifying Surge and QX output files in `vpn_merger.py`
- expose new config options `surge_file` and `qx_file`
- add unit tests for Surge/QX converters

## Testing
- `pip install -r requirements.txt`
- `pip install -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f5d910dc832681d3988f1997c86d