### PR TITLE
Add extended QUIC parsing and tests

### DIFF
--- a/tests/test_aggregator_clash_proxy.py
+++ b/tests/test_aggregator_clash_proxy.py
@@ -34,7 +34,10 @@ def test_aggregator_clash_proxy(tmp_path):
         vmess_link,
         vless_link,
         ssr_link,
-        "reality://uuid@host:443?flow=xtls-rprx-vision&sni=site.com&fp=chrome",
+        (
+            "reality://uuid@host:443?flow=xtls-rprx-vision&publicKey=pub"
+            "&short-id=123&sni=site.com&fp=chrome"
+        ),
         "naive://user:pass@host:443",
     ]
     aggregator_tool.output_files(configs, tmp_path, cfg)
@@ -44,6 +47,8 @@ def test_aggregator_clash_proxy(tmp_path):
     assert reality["tls"] is True
     assert reality["sni"] == "site.com"
     assert reality["fp"] == "chrome"
+    assert reality["reality-opts"]["public-key"] == "pub"
+    assert reality["reality-opts"]["short-id"] == "123"
 
     vmess = next(p for p in data["proxies"] if p["type"] == "vmess")
     assert vmess["network"] == "ws"

--- a/tests/test_clash_parsing_extra.py
+++ b/tests/test_clash_parsing_extra.py
@@ -49,6 +49,19 @@ def test_reality_parse_extra():
     assert proxy["name"] == "test"
 
 
+def test_reality_parse_synonyms():
+    link = (
+        "reality://id@host:443?flow=xtls-rprx-splice&publicKey=pub"
+        "&short_id=456"
+    )
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["flow"] == "xtls-rprx-splice"
+    assert proxy["pbk"] == "pub"
+    assert proxy["sid"] == "456"
+    assert proxy["reality-opts"]["public-key"] == "pub"
+    assert proxy["reality-opts"]["short-id"] == "456"
+
+
 def test_hysteria2_parse():
     link = "hy2://pass@host:443?peer=example.com&insecure=1&upmbps=10&downmbps=20"
     proxy = config_to_clash_proxy(link, 0)
@@ -62,6 +75,14 @@ def test_hysteria2_parse():
     assert proxy["downmbps"] == "20"
 
 
+def test_hysteria2_parse_v5():
+    link = "hy2://host:443?password=pw&up=5&down=10"
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["password"] == "pw"
+    assert proxy["upmbps"] == "5"
+    assert proxy["downmbps"] == "10"
+
+
 def test_hysteria2_invalid():
     assert config_to_clash_proxy("hy2://host", 0) is None
 
@@ -73,6 +94,18 @@ def test_tuic_parse():
     assert proxy["uuid"] == "uuid"
     assert proxy["password"] == "pw"
     assert proxy["alpn"] == "h3"
+
+
+def test_tuic_parse_v5():
+    link = (
+        "tuic://host:443?uuid=u123&password=p456&congestion_control=bbr"
+        "&udp_relay_mode=native"
+    )
+    proxy = config_to_clash_proxy(link, 0)
+    assert proxy["uuid"] == "u123"
+    assert proxy["password"] == "p456"
+    assert proxy["congestion-control"] == "bbr"
+    assert proxy["udp-relay-mode"] == "native"
 
 
 def test_vless_parse_ws_headers():

--- a/tests/test_clash_proxies_yaml.py
+++ b/tests/test_clash_proxies_yaml.py
@@ -37,7 +37,10 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
         source_url="s",
     )
     res4 = ConfigResult(
-        config="reality://uuid@host:443?flow=xtls-rprx-vision&pbk=pub&sid=123",
+        config=(
+            "reality://uuid@host:443?flow=xtls-rprx-vision&publicKey=pub"
+            "&short_id=123"
+        ),
         protocol="Reality",
         host="host",
         port=443,
@@ -47,8 +50,8 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     )
     res5 = ConfigResult(
         config=(
-            "tuic://uuid:pw@host:10443?alpn=h3&congestion-control=bbr"
-            "&udp-relay-mode=native"
+            "tuic://host:10443?uuid=uuid&password=pw&alpn=h3"
+            "&congestion_control=bbr&udp_relay_mode=native"
         ),
         protocol="TUIC",
         host="host",
@@ -59,8 +62,8 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     )
     res6 = ConfigResult(
         config=(
-            "hy2://pass@host:8443?peer=example.com&insecure=1&obfs=obfs"
-            "&obfs-password=secret"
+            "hy2://host:8443?password=pass&peer=example.com&insecure=1"
+            "&obfs=obfs&obfs-password=secret&up=5&down=10"
         ),
         protocol="Hysteria2",
         host="host",
@@ -100,6 +103,8 @@ def test_clash_proxies_yaml(tmp_path, monkeypatch):
     assert hy2["insecure"] == "1"
     assert hy2["obfs"] == "obfs"
     assert hy2["obfs_password"] == "secret"
+    assert hy2["upmbps"] == "5"
+    assert hy2["downmbps"] == "10"
 
     singbox = tmp_path / "vpn_singbox.json"
     assert singbox.exists()


### PR DESCRIPTION
## Summary
- support extra `public_key`/`short_id` options for Reality links
- parse TUIC and Hysteria2 v5 query parameters
- check `reality-opts` when exporting aggregator results
- ensure Clash/Sing-box outputs handle updated protocols

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873fc62f9e08326bb741c53f3049e84