### PR TITLE
Add geoip naming and proxy group improvements

### DIFF
--- a/src/massconfigmerger/clash_utils.py
+++ b/src/massconfigmerger/clash_utils.py
@@ -445,17 +445,19 @@ def build_clash_config(proxies: List[Dict[str, Any]]) -> str:
         return ""
 
     names = [p["name"] for p in proxies]
+    auto_select = "⚡ Auto-Select"
+    manual = "🔰 MANUAL"
     groups = [
         {
-            "name": "⚡ Auto-Select",
+            "name": auto_select,
             "type": "url-test",
             "proxies": names,
             "url": "http://www.gstatic.com/generate_204",
             "interval": 300,
         },
-        {"name": "🔰 MANUAL", "type": "select", "proxies": names},
+        {"name": manual, "type": "select", "proxies": [auto_select, *names]},
     ]
-    rules = ["MATCH, ⚡ Auto-Select"]
+    rules = [f"MATCH,{manual}"]
     return yaml.safe_dump(
         {"proxies": proxies, "proxy-groups": groups, "rules": rules},
         allow_unicode=True,

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -1133,13 +1133,21 @@ class UltimateVPNMerger:
                 tmp_csv = csv_file.with_suffix('.tmp')
                 with open(tmp_csv, 'w', newline='', encoding='utf-8') as f:
                     writer = csv.writer(f)
-                    writer.writerow(['Config', 'Protocol', 'Host', 'Port', 'Ping_MS', 'Reachable', 'Source', 'Country'])
+                    writer.writerow([
+                        'config', 'protocol', 'host', 'port',
+                        'ping_ms', 'reachable', 'source_url', 'country'
+                    ])
                     for result in results:
                         ping_ms = round(result.ping_time * 1000, 2) if result.ping_time else None
                         writer.writerow([
-                            result.config, result.protocol, result.host, result.port,
-                            ping_ms, result.is_reachable, result.source_url,
-                            result.country
+                            result.config,
+                            result.protocol,
+                            result.host,
+                            result.port,
+                            ping_ms,
+                            result.is_reachable,
+                            result.source_url,
+                            result.country,
                         ])
                 tmp_csv.replace(csv_file)
         


### PR DESCRIPTION
## Summary
- enhance Clash config generation to include manual selection group
- update CSV report headers and content to include protocol and source URL
- adjust tests for new YAML structure and naming scheme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687403adc90c8326b726d8cc033fad32