### PR TITLE
Move test deps to dev requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,7 +824,8 @@ Install the `geoip2` package and download the free GeoLite2 database from MaxMin
 
 ## Testing
 
-Run `pytest` to execute the test suite. Install dependencies first with:
+Run `pytest` to execute the test suite. Make sure to install both the runtime
+and development dependencies first:
 
 ```bash
 pip install -r requirements.txt -r dev-requirements.txt


### PR DESCRIPTION
## Summary
- clarify that development requirements must be installed before running tests

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740a94245c8326af6e6d8a36e0035b