### PR TITLE
Add resolver cleanup

### DIFF
--- a/src/massconfigmerger/tester.py
+++ b/src/massconfigmerger/tester.py
@@ -92,3 +92,15 @@ class NodeTester:
             logging.debug("GeoIP lookup failed: %s", exc)
             return None
 
+    async def close(self) -> None:
+        """Close any resolver resources if initialized."""
+        if self.resolver is not None:
+            try:
+                close = getattr(self.resolver, "close", None)
+                if asyncio.iscoroutinefunction(close):
+                    await close()  # type: ignore[misc]
+                elif callable(close):
+                    close()
+            except Exception as exc:  # pragma: no cover - env specific
+                logging.debug("Resolver close failed: %s", exc)
+            self.resolver = None

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -738,6 +738,9 @@ class UltimateVPNMerger:
         await self._save_proxy_history()
 
         self._print_final_summary(len(unique_results), time.time() - self.start_time, stats)
+
+        # Clean up tester resources
+        await self.processor.tester.close()
     
     async def _test_and_filter_sources(self) -> List[str]:
         """Test all sources for availability and filter out dead links."""

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -32,7 +32,10 @@ async def retest_configs(configs: List[str]) -> List[Tuple[str, Optional[float]]
             return await _test_config(proc, cfg)
 
     tasks = [asyncio.create_task(worker(c)) for c in configs]
-    return await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Testing")
+    try:
+        return await tqdm_asyncio.gather(*tasks, total=len(tasks), desc="Testing")
+    finally:
+        await proc.tester.close()
 
 
 def load_configs(path: Path) -> List[str]:

--- a/tests/test_tester_close.py
+++ b/tests/test_tester_close.py
@@ -1,0 +1,53 @@
+import asyncio
+import types
+import pytest
+
+from massconfigmerger.tester import NodeTester
+from massconfigmerger.config import Settings
+from massconfigmerger import vpn_retester
+
+
+class DummyResolver:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_node_tester_close():
+    tester = NodeTester(Settings())
+    dummy = DummyResolver()
+    tester.resolver = dummy
+    await tester.close()
+    assert dummy.closed
+    assert tester.resolver is None
+
+
+@pytest.mark.asyncio
+async def test_retest_configs_closes_tester(monkeypatch):
+    closed = False
+
+    class DummyTester:
+        async def test_connection(self, host, port):
+            return 0.1
+
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    class DummyProcessor:
+        def __init__(self):
+            self.tester = DummyTester()
+
+        def extract_host_port(self, cfg):
+            return "example.com", 80
+
+        async def test_connection(self, host, port):
+            return await self.tester.test_connection(host, port)
+
+    monkeypatch.setattr(vpn_retester, "EnhancedConfigProcessor", DummyProcessor)
+
+    await vpn_retester.retest_configs(["dummy"])
+    assert closed


### PR DESCRIPTION
## Summary
- add a `close()` coroutine in `NodeTester`
- clean up tester resolver in merger and retester scripts
- test that the resolver cleanup method is called

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743c673964832690f11f1d94db607c