### PR TITLE
Add optional aggregator and retester services

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
   respect Telegram's Terms of Service along with your local laws.
 - All events are logged to the directory specified in `log_dir` (defaults to
   `logs/` here) so you can audit what was fetched and from where.
+
+### Docker Compose Automation
+
+The included `docker-compose.yml` automates running the scripts. `vpn_merger`
+loops every `$MERGE_INTERVAL` seconds (default `86400`). Enable the optional
+`aggregator` profile to fetch new links on a schedule. It runs
+`aggregator_tool.py --with-merger` every `$AGGREGATE_INTERVAL` seconds
+(default `43200`). The `retester` profile repeatedly runs
+`vpn_retester.py` in the same way.
+
+Start all services with:
+
+```bash
+docker compose up -d
+```
+
+Add profiles as needed, for example:
+
+```bash
+docker compose --profile aggregator --profile retester up -d
+```
 ## FAQ
 
 ### Why does the script take so long?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,31 @@ services:
              done"
     environment:
       - MERGE_INTERVAL=86400
+
+  aggregator:
+    profiles: ["aggregator"]
+    build: .
+    image: vpn-merger
+    volumes:
+      - ./output:/app/output
+    command: >
+      sh -c "while true; do \
+                python aggregator_tool.py --with-merger && echo 'Waiting for next aggregation'; \
+                sleep ${AGGREGATE_INTERVAL:-43200}; \
+             done"
+    environment:
+      - AGGREGATE_INTERVAL=43200
+
+  vpn_retester:
+    profiles: ["retester"]
+    build: .
+    image: vpn-merger
+    volumes:
+      - ./output:/app/output
+    command: >
+      sh -c "while true; do \
+                python vpn_retester.py && echo 'Waiting for next retest'; \
+                sleep ${RETEST_INTERVAL:-86400}; \
+             done"
+    environment:
+      - RETEST_INTERVAL=86400

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -67,9 +67,14 @@ By default the `vpn_merger` service runs once a day. Start the optional
 ```bash
 docker compose --profile aggregator up -d
 ```
+To periodically retest existing results, start `vpn_retester` as well:
 
-Adjust `MERGE_INTERVAL` and `AGGREGATE_INTERVAL` in `docker-compose.yml` to
-change how frequently each script runs.
+```bash
+docker compose --profile retester up -d
+```
+
+Adjust `MERGE_INTERVAL` (default `86400`) and `AGGREGATE_INTERVAL` (default
+`43200`) in `docker-compose.yml` to change how frequently each script runs.
 
 ### Docker Compose / Local Scheduling
 
@@ -84,8 +89,9 @@ Start it with:
 docker compose up -d
 ```
 
-The container runs the script once a day by default. Set the `MERGE_INTERVAL`
-environment variable in `docker-compose.yml` to change how often it runs.
+The container runs the script once a day by default. Set `MERGE_INTERVAL` and
+`AGGREGATE_INTERVAL` in `docker-compose.yml` to change how often the merger and
+aggregator run.
 
 ## ✨ Key Features & Use Cases
 


### PR DESCRIPTION
## Summary
- add aggregator and vpn_retester services to docker-compose
- document AGGREGATE_INTERVAL and MERGE_INTERVAL env variables
- update tutorial and README for new docker-compose services

## Testing
- `pip install -r requirements.txt`
- `pip install -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874403d9db483268100963ea69a263e