### PR TITLE
Fix loop compatibility with get_loop

### DIFF
--- a/src/massconfigmerger/__init__.py
+++ b/src/massconfigmerger/__init__.py
@@ -1,0 +1,13 @@
+"""MassConfigMerger package initialization."""
+
+from __future__ import annotations
+
+import aiohttp
+
+
+if not hasattr(aiohttp.ClientSession, "get_loop"):
+    def _get_loop(self: aiohttp.ClientSession):
+        return self.loop
+
+    aiohttp.ClientSession.get_loop = _get_loop  # type: ignore[attr-defined]
+

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -168,7 +168,12 @@ async def fetch_text(
         return None
 
     attempt = 0
-    use_temp = hasattr(session, "loop") and session.loop is not asyncio.get_running_loop()
+    if hasattr(session, "get_loop"):
+        use_temp = session.get_loop() is not asyncio.get_running_loop()
+    elif hasattr(session, "loop"):
+        use_temp = session.loop is not asyncio.get_running_loop()
+    else:
+        use_temp = False
     if use_temp:
         session = aiohttp.ClientSession(proxy=proxy) if proxy else aiohttp.ClientSession()
     while attempt < retries:

--- a/src/massconfigmerger/source_fetcher.py
+++ b/src/massconfigmerger/source_fetcher.py
@@ -144,7 +144,15 @@ class AsyncSourceFetcher:
     async def test_source_availability(self, url: str) -> bool:
         """Test if a source URL is available (returns 200 status)."""
         session = self.session
-        if session is None or getattr(session, "loop", None) is not asyncio.get_running_loop():
+        if session is None:
+            loop_check = None
+        elif hasattr(session, "get_loop"):
+            loop_check = session.get_loop()
+        elif hasattr(session, "loop"):
+            loop_check = session.loop
+        else:
+            loop_check = asyncio.get_running_loop()
+        if session is None or loop_check is not asyncio.get_running_loop():
             session = aiohttp.ClientSession()
             close_temp = True
         else:
@@ -174,7 +182,15 @@ class AsyncSourceFetcher:
     async def fetch_source(self, url: str) -> Tuple[str, List[ConfigResult]]:
         """Fetch single source with comprehensive testing and deduplication."""
         session = self.session
-        use_temp = session is None or getattr(session, "loop", None) is not asyncio.get_running_loop()
+        if session is None:
+            loop_check = None
+        elif hasattr(session, "get_loop"):
+            loop_check = session.get_loop()
+        elif hasattr(session, "loop"):
+            loop_check = session.loop
+        else:
+            loop_check = asyncio.get_running_loop()
+        use_temp = session is None or loop_check is not asyncio.get_running_loop()
         if use_temp:
             session = aiohttp.ClientSession()
         for attempt in range(CONFIG.max_retries):


### PR DESCRIPTION
## Summary
- ensure aiohttp compatibility by adding a fallback `get_loop` method
- use `session.get_loop()` when deciding to create temporary sessions
- keep compatibility with older sessions without a `get_loop` attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743f62d8508326a5f1edf01ff3c85c