### PR TITLE
Centralize regex constants

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -31,7 +31,7 @@ from telethon import TelegramClient, events, errors  # type: ignore
 from telethon.tl.custom.message import Message  # type: ignore
 from . import vpn_merger
 
-from .constants import SOURCES_FILE
+from .constants import SOURCES_FILE, PROTOCOL_RE, BASE64_RE
 
 from .config import Settings, load_config
 
@@ -44,16 +44,7 @@ CONFIG_FILE = Path("config.yaml")
 CHANNELS_FILE = Path("channels.txt")
 
 # Match full config links for supported protocols
-PROTOCOL_RE = re.compile(
-    r"(?:"
-    r"vmess|vless|reality|ssr?|trojan|hy2|hysteria2?|tuic|"
-    r"shadowtls|juicity|naive|brook|wireguard|"
-    r"socks5|socks4|socks|http|https|grpc|ws|wss|"
-    r"tcp|kcp|quic|h2"
-    r")://\S+",
-    re.IGNORECASE,
-)
-BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
+# (PROTOCOL_RE and BASE64_RE imported from constants)
 HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 
 # Safety limit for base64 decoding to avoid huge payloads

--- a/src/massconfigmerger/constants.py
+++ b/src/massconfigmerger/constants.py
@@ -1,3 +1,16 @@
 from pathlib import Path
+import re
 
 SOURCES_FILE = Path("sources.txt")
+
+# Regular expressions shared across modules
+PROTOCOL_RE = re.compile(
+    r"(?:"
+    r"vmess|vless|reality|ssr?|trojan|hy2|hysteria2?|tuic|"
+    r"shadowtls|juicity|naive|brook|wireguard|"
+    r"socks5|socks4|socks|http|https|grpc|ws|wss|"
+    r"tcp|kcp|quic|h2"
+    r")://\S+",
+    re.IGNORECASE,
+)
+BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")


### PR DESCRIPTION
## Summary
- centralize protocol and base64 regex patterns in `constants.py`
- import the shared patterns in `aggregator_tool`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743f6443f08326a53a225b8966f04a