### PR TITLE
Clarify protocol filtering in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 
 > **Note**: The default protocol list is optimised for the Hiddify client. Other VPN apps may require adjusting `--include-protocols`.
 
+> **How protocols are filtered**
+>
+> The `protocols` list in the **Aggregator options** section of
+> [`config.yaml.example`](config.yaml.example) controls which types of links are
+> collected from each source. Reduce this list if you only want certain
+> protocols to speed up scraping.
+>
+> Later the merger applies its own `include_protocols` list (see the **Merger
+> options** in `config.yaml.example`) to drop any unwanted protocols before
+> writing the final files. Adjust this list to match what your VPN client
+> supports or to exclude protocols you don't trust.
+
 **Important**: Install the dependencies with `pip install -r requirements.txt` before running **any** of the Python scripts.
 
 ### ⚡ Quick Start


### PR DESCRIPTION
## Summary
- document how aggregator `protocols` differ from merger `include_protocols`
- mention typical reasons to edit each list and link to `config.yaml.example`

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874c77529b88326972bab5cd78e3a4e