### PR TITLE
chore: extend default VPN sources

### DIFF
--- a/channels.txt
+++ b/channels.txt
@@ -23,6 +23,7 @@ https://t.me/V2XCore
 https://t.me/V2rayEnglish
 https://t.me/aurora_vpn
 https://t.me/azadi_az_inja_migzare
+https://t.me/azadnet
 https://t.me/bored_vpn
 https://t.me/byteforge_chan
 https://t.me/clashfree
@@ -36,6 +37,7 @@ https://t.me/mobilesignal
 https://t.me/netmelli15
 https://t.me/nim_vpn_ir
 https://t.me/outline_vpn
+https://t.me/proxystore11
 https://t.me/proxyy_1404
 https://t.me/prrofile_purple
 https://t.me/rwin6

--- a/sources.txt
+++ b/sources.txt
@@ -487,6 +487,7 @@ https://raw.githubusercontent.com/MrMohebi/xray-proxy-grabber-telegram/master/co
 https://raw.githubusercontent.com/NiceVPN123/NiceVPN/main/Clash.yaml
 https://raw.githubusercontent.com/PangTouY00/Auto_proxy/main/Long_term_subscription_num
 https://raw.githubusercontent.com/Vauth/node/main/Main
+https://raw.githubusercontent.com/aiboboxx/clashfree/main/clash.yaml
 https://raw.githubusercontent.com/aiboboxx/clashfree/main/clash.yml
 https://raw.githubusercontent.com/chengaopan/AutoMergePublicNodes/master/list.yml
 https://raw.githubusercontent.com/lagzian/SS-Collector/main/mix_clash.yaml


### PR DESCRIPTION
## Summary
- add new VPN repository link for `aiboboxx/clashfree` with `.yaml`
- include new Telegram channels `@azadnet` and `@proxystore11`

## Testing
- `pip install -r requirements.txt -r dev-requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68755204280083268f1b1b80cb5f8ada