### PR TITLE
Initialize colorama in vpn_merger

### DIFF
--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -42,6 +42,12 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast, Callable,
 from urllib.parse import urlparse, parse_qs
 from tqdm import tqdm
 
+try:
+    import colorama
+    colorama.just_fix_windows_console()
+except Exception:
+    pass
+
 from .source_fetcher import (
     fetch_text,
     parse_first_configs,


### PR DESCRIPTION
## Summary
- ensure colorama is imported before printing colored text
- initialize colorama for Windows console on import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875789f61208326ab22795515c09929