### PR TITLE
Remove deprecated loop property patch

### DIFF
--- a/src/massconfigmerger/__init__.py
+++ b/src/massconfigmerger/__init__.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import aiohttp
 
 
-if not hasattr(aiohttp.ClientSession, "get_loop"):
-    def _get_loop(self: aiohttp.ClientSession):
-        return self.loop
-
-    aiohttp.ClientSession.get_loop = _get_loop  # type: ignore[attr-defined]
+def get_client_loop(session: aiohttp.ClientSession) -> asyncio.AbstractEventLoop | None:
+    """Return the event loop used by ``session`` if it can be determined."""
+    get_loop = getattr(session, "get_loop", None)
+    if callable(get_loop):
+        try:
+            return get_loop()
+        except RuntimeError:
+            return None
+    return getattr(session, "_loop", None)
 

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -30,6 +30,7 @@ import yaml
 
 import aiohttp
 from aiohttp import ClientSession, ClientTimeout
+from . import get_client_loop
 from tqdm import tqdm
 from telethon import TelegramClient, events, errors  # type: ignore
 from telethon.tl.custom.message import Message  # type: ignore
@@ -171,12 +172,8 @@ async def fetch_text(
         return None
 
     attempt = 0
-    if hasattr(session, "get_loop"):
-        use_temp = session.get_loop() is not asyncio.get_running_loop()
-    elif hasattr(session, "loop"):
-        use_temp = session.loop is not asyncio.get_running_loop()
-    else:
-        use_temp = False
+    session_loop = get_client_loop(session)
+    use_temp = session_loop is not None and session_loop is not asyncio.get_running_loop()
     if use_temp:
         session = aiohttp.ClientSession(proxy=proxy) if proxy else aiohttp.ClientSession()
     while attempt < retries:


### PR DESCRIPTION
## Summary
- drop monkeypatch of `aiohttp.ClientSession.get_loop`
- add `get_client_loop` helper
- use `get_client_loop` in aggregator and fetcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875f7ee815c8326ba464d1cb7430994