### PR TITLE
Update vmess base64 validation

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -89,7 +89,7 @@ def is_valid_config(link: str) -> bool:
     if scheme == "vmess":
         padded = rest + "=" * (-len(rest) % 4)
         try:
-            json.loads(base64.b64decode(padded).decode())
+            json.loads(base64.b64decode(padded, validate=True).decode())
             return True
         except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
             logging.warning("Invalid vmess config: %s", exc)


### PR DESCRIPTION
## Summary
- use `validate=True` when decoding `vmess://` payloads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687601237bac832682a285495745bc02