### PR TITLE
Remove unused _get_script_dir helpers

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -63,15 +63,6 @@ HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 # Safety limit for base64 decoding to avoid huge payloads
 MAX_DECODE_SIZE = 256 * 1024  # 256 kB
 
-
-def _get_script_dir() -> Path:
-    """Return a safe base directory for writing output."""
-    try:
-        return Path(__file__).resolve().parent
-    except NameError:
-        return Path.cwd()
-
-
 def extract_subscription_urls(text: str) -> Set[str]:
     """Return all HTTP(S) URLs in the text block."""
     return set(HTTP_RE.findall(text))

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -874,18 +874,6 @@ async def run_in_jupyter(sources_file: Optional[Union[str, Path]] = None):
     print("🔄 Running in Jupyter/async environment")
     await main_async(sources_file)
 
-def _get_script_dir() -> Path:
-    """
-    Return a safe base directory for writing output.
-    • In a regular script run, that’s the directory the script lives in.
-    • In interactive/Jupyter runs, fall back to the current working dir.
-    """
-    try:
-        return Path(__file__).resolve().parent        # normal execution
-    except NameError:
-        return Path.cwd()                             # Jupyter / interactive
-
-
 def main():
     """Main entry point with event loop detection."""
     if sys.version_info < (3, 8):


### PR DESCRIPTION
## Summary
- delete `_get_script_dir` helper from aggregator and vpn merger modules
- clean up surrounding blank lines

## Testing
- `pip install -r dev-requirements.txt`
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876010cf4688326a91cace7ab233ab5