### PR TITLE
Trim usage block and add help hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 9. **Import your subscription**
    - Use the link in `output/vpn_subscription_base64.txt` (unless `--no-base64` was used) or load `vpn_singbox.json` in clients like sing-box.
 
+> **Need more options?** Run `vpn-merger --help-extra` or see
+> [docs/tutorial.md](docs/tutorial.md) for the full walkthrough.
+
 
 ## 📖 Table of Contents
 

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -987,7 +987,16 @@ def main():
         default=None,
         help="Comma-separated ISO codes to exclude when GeoIP is enabled",
     )
+    parser.add_argument(
+        "--help-extra",
+        action="store_true",
+        help="Show extended usage information and exit",
+    )
     args, unknown = parser.parse_known_args()
+    if args.help_extra:
+        parser.print_help()
+        print("\nFor a complete tutorial see docs/tutorial.md")
+        return 0
     if unknown:
         logging.warning("Ignoring unknown arguments: %s", unknown)
 
@@ -1055,44 +1064,3 @@ def main():
         print("\n📋 Alternative execution methods:")
         print("   • For Jupyter: await run_in_jupyter()")
         print("   • For scripts: python script.py")
-
-if __name__ == "__main__":
-    main()
-
-    # ========================================================================
-    # USAGE INSTRUCTIONS
-    # ========================================================================
-
-    print(
-        """\
-🚀 VPN Subscription Merger - Final Unified Edition
-
-📋 Execution Methods:
-   • Regular Python: python script.py
-   • Jupyter/IPython: await run_in_jupyter()
-   • With event loop errors: task = detect_and_run(); await task
-
-🎯 Unified Features:
-   • Sources loaded from `sources.txt` (over 450 links)
-   • Dead link detection and automatic removal
-   • Real-time server reachability testing with response time measurement
-   • Smart sorting by connection speed and protocol preference
-   • Advanced semantic deduplication
-   • Multiple output formats (raw, base64, CSV with performance data, JSON)
-   • Event loop compatibility for all environments
-   • Comprehensive error handling and retry logic
-
-📊 Expected Results:
-   • 800k-1.2M+ tested and sorted configs
-   • 70-85% configs will be reachable and validated
-   • Processing time: 8-12 minutes with full testing
-   • Dead sources automatically filtered out
-   • Performance-optimized final list
-
-📁 Output Files:
-   • vpn_subscription_raw.txt (for hosting)
-   • vpn_subscription_base64.txt (optional, for direct import)
-   • vpn_detailed.csv (optional, with performance metrics)
-   • vpn_report.json (comprehensive statistics)
-"""
-    )


### PR DESCRIPTION
## Summary
- remove large usage block from `vpn_merger.py`
- add `--help-extra` CLI option that prints link to tutorial
- document the help option in README under the Quick Start usage steps

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68764ac136b88326b4fbe06046acb3b4