### PR TITLE
Clarify dev install before running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,11 +272,11 @@ Install the `geoip2` package and download the free GeoLite2 database from MaxMin
 
 ## Testing
 
-Run `pytest` to execute the test suite. **The package must be installed in
-editable mode with the development extras**, otherwise running the tests will
-raise `ModuleNotFoundError` when modules like `massconfigmerger` or the testing
-tools themselves are missing. Install the runtime and development dependencies
-using the `dev` extras or the convenience requirements file:
+Run the tests with `pytest`. Install the project in editable mode with the
+development extras first to ensure all dependencies are available. Skipping this
+step will result in `ModuleNotFoundError` when modules like `massconfigmerger`
+or the testing tools are missing. You can use the convenience requirements file
+instead:
 
 ```bash
 pip install -e .[dev]

--- a/docs/advanced-troubleshooting.md
+++ b/docs/advanced-troubleshooting.md
@@ -88,3 +88,16 @@ New files will appear in the chosen output directory:
    - *Best Value*: `4` which balances speed and resource usage.
    - *Default*: `4`.
 
+### Running the tests
+
+If you want to run the project's unit tests, install the package in editable
+mode with the development extras before invoking `pytest`:
+
+```bash
+pip install -e .[dev]
+pytest
+```
+
+Failing to install the `dev` extras first will result in `ModuleNotFoundError`
+when the test suite tries to import `massconfigmerger`.
+


### PR DESCRIPTION
## Summary
- instruct to install dev extras before running tests in README and advanced troubleshooting docs

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68774f3f13cc8326ada806bb0b92a598