### PR TITLE
Refactor protocol helpers into utils module

### DIFF
--- a/src/massconfigmerger/result_processor.py
+++ b/src/massconfigmerger/result_processor.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse, parse_qs, urlencode, urlunparse, parse_qsl
 
 from .config import Settings, load_config
 from .tester import NodeTester
+from .utils import is_valid_config, parse_configs_from_text
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().with_name("config.yaml")
 try:

--- a/src/massconfigmerger/utils.py
+++ b/src/massconfigmerger/utils.py
@@ -1,0 +1,116 @@
+"""Utility helpers for protocol detection and parsing."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import re
+from urllib.parse import urlparse
+from typing import Set
+
+from .constants import PROTOCOL_RE, BASE64_RE
+
+# Safety limit for base64 decoding to avoid huge payloads
+MAX_DECODE_SIZE = 256 * 1024  # 256 kB
+
+
+def is_valid_config(link: str) -> bool:
+    """Simple validation for known protocols."""
+    if "warp://" in link:
+        return False
+
+    scheme, _, rest = link.partition("://")
+    scheme = scheme.lower()
+    rest = re.split(r"[?#]", rest, 1)[0]
+
+    if scheme == "vmess":
+        padded = rest + "=" * (-len(rest) % 4)
+        try:
+            json.loads(base64.b64decode(padded, validate=True).decode())
+            return True
+        except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            logging.warning("Invalid vmess config: %s", exc)
+            return False
+
+    if scheme == "ssr":
+        encoded = rest
+        padded = encoded + "=" * (-len(encoded) % 4)
+        try:
+            decoded = base64.urlsafe_b64decode(padded).decode()
+        except (binascii.Error, UnicodeDecodeError) as exc:
+            logging.warning("Invalid ssr config encoding: %s", exc)
+            return False
+        host_part = decoded.split("/", 1)[0]
+        if ":" not in host_part:
+            return False
+        host, port = host_part.split(":", 1)
+        return bool(host and port)
+
+    host_required = {
+        "naive",
+        "hy2",
+        "vless",
+        "trojan",
+        "reality",
+        "hysteria",
+        "hysteria2",
+        "tuic",
+        "ss",
+    }
+    if scheme in host_required:
+        if "@" not in rest:
+            return False
+        host = rest.split("@", 1)[1].split("/", 1)[0]
+        return ":" in host
+
+    simple_host_port = {
+        "http",
+        "https",
+        "grpc",
+        "ws",
+        "wss",
+        "socks",
+        "socks4",
+        "socks5",
+        "tcp",
+        "kcp",
+        "quic",
+        "h2",
+    }
+    if scheme in simple_host_port:
+        parsed = urlparse(link)
+        return bool(parsed.hostname and parsed.port)
+    if scheme == "wireguard":
+        return bool(rest)
+
+    return bool(rest)
+
+
+def parse_configs_from_text(text: str) -> Set[str]:
+    """Extract all config links from a text block."""
+    configs: Set[str] = set()
+    for line in text.splitlines():
+        line = line.strip()
+        matches = PROTOCOL_RE.findall(line)
+        if matches:
+            configs.update(matches)
+            continue
+        if BASE64_RE.match(line):
+            if len(line) > MAX_DECODE_SIZE:
+                logging.debug(
+                    "Skipping oversized base64 line (%d > %d)",
+                    len(line),
+                    MAX_DECODE_SIZE,
+                )
+                continue
+            try:
+                padded = line + "=" * (-len(line) % 4)
+                decoded = base64.urlsafe_b64decode(padded).decode()
+                configs.update(PROTOCOL_RE.findall(decoded))
+            except (binascii.Error, UnicodeDecodeError) as exc:
+                logging.debug("Failed to decode base64 line: %s", exc)
+                continue
+    return configs
+

--- a/tests/test_parse_configs.py
+++ b/tests/test_parse_configs.py
@@ -1,11 +1,11 @@
 import base64
 
-from massconfigmerger import aggregator_tool
+from massconfigmerger import utils
 
 
 def test_multiple_links_same_line():
     text = "vmess://a vless://b"
-    result = aggregator_tool.parse_configs_from_text(text)
+    result = utils.parse_configs_from_text(text)
     assert "vmess://a" in result
     assert "vless://b" in result
     assert len(result) == 2
@@ -31,21 +31,21 @@ def test_extract_all_protocols():
             "wireguard://o",
         ]
     )
-    result = aggregator_tool.parse_configs_from_text(text)
+    result = utils.parse_configs_from_text(text)
     assert len(result) == 15
     for item in text.split():
         assert item in result
 
 
 def test_parse_oversized_line(caplog):
-    big_line = "A" * (aggregator_tool.MAX_DECODE_SIZE + 1)
+    big_line = "A" * (utils.MAX_DECODE_SIZE + 1)
     with caplog.at_level('DEBUG'):
-        result = aggregator_tool.parse_configs_from_text(big_line)
+        result = utils.parse_configs_from_text(big_line)
     assert result == set()
     assert "Skipping oversized base64 line" in caplog.text
 
 
 def test_urlsafe_base64_line():
     encoded = base64.urlsafe_b64encode(b"vmess://a  >").decode()
-    result = aggregator_tool.parse_configs_from_text(encoded)
+    result = utils.parse_configs_from_text(encoded)
     assert result == {"vmess://a"}

--- a/tests/test_valid_config.py
+++ b/tests/test_valid_config.py
@@ -1,7 +1,7 @@
 import base64
 import json
 
-from massconfigmerger.aggregator_tool import is_valid_config
+from massconfigmerger.utils import is_valid_config
 
 def test_vmess_with_fragment_accepted():
     data = {"v": "2", "ps": "test"}


### PR DESCRIPTION
## Summary
- share `is_valid_config` and `parse_configs_from_text` in new `utils` module
- import helpers from utils in aggregator tool and result processor
- update tests to use the helpers via utils

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775210e1cc8326ae76f3e517e76d79