### PR TITLE
Standardize subscription filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
    massconfigmerger fetch --hours 12
    ```
 
-   `aggregator_tool.py` on its own creates `output/merged.txt` (plus `merged_base64.txt` and `merged_singbox.json`) and a log file under `logs/` named by the current date.
+`aggregator_tool.py` on its own creates `output/vpn_subscription_raw.txt` (plus
+`vpn_subscription_base64.txt` and `vpn_singbox.json`) and a log file under `logs/`
+named by the current date.
 
 5. **Merge and sort the results**
 
@@ -83,7 +85,8 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
    massconfigmerger merge
    ```
 
-   Use `--resume output/merged.txt` to continue a previous run without re-downloading.
+Use `--resume output/vpn_subscription_raw.txt` to continue a previous run without
+re-downloading.
 
 6. **All in one step**
 
@@ -134,9 +137,6 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 
 | File Name                              | Purpose                                                                                                  |
 | -------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `merged.txt` | Raw links collected from all sources. |
-| `merged_base64.txt` | Base64-encoded version of `merged.txt`. |
-| `merged_singbox.json` | Basic sing-box JSON from the aggregator. |
 | `vpn_subscription_base64.txt` | *(optional)* A base64-encoded file. Most apps import directly from this file's raw URL.                  |
 | `vpn_subscription_raw.txt`    | A plain text list of all the VPN configuration links.                                                    |
 | `vpn_detailed.csv`            | *(optional)* A spreadsheet with detailed info about each server, including protocol, host, and ping time. |

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -14,22 +14,20 @@ import base64
 import binascii
 import json
 import logging
-import random
+import random  # noqa: F401 - used in tests for monkeypatching
 import re
-import sys
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Iterable, List, Set, Optional, Dict, Union, Tuple, cast, Any
-from urllib.parse import urlparse
+from typing import Iterable, List, Set, Dict, Tuple, cast, Any
 from .clash_utils import config_to_clash_proxy, build_clash_config
 
 import io
 from contextlib import redirect_stdout
 
-import yaml
+
 
 import aiohttp
-from aiohttp import ClientSession, ClientTimeout
+from aiohttp import ClientSession
 from .source_fetcher import fetch_text
 from tqdm import tqdm
 from telethon import TelegramClient, events, errors  # type: ignore
@@ -38,7 +36,6 @@ from . import vpn_merger
 
 from .constants import SOURCES_FILE
 from .utils import (
-    MAX_DECODE_SIZE,
     is_valid_config,
     parse_configs_from_text,
 )
@@ -222,7 +219,7 @@ async def scrape_telegram_configs(
     with channels_path.open() as f:
         channels = [
             (
-                line.strip()[len(prefix) :]
+                line.strip()[len(prefix):]
                 if line.strip().startswith(prefix)
                 else line.strip()
             )
@@ -335,13 +332,13 @@ def output_files(configs: List[str], out_dir: Path, cfg: Settings) -> List[Path]
     out_dir.mkdir(parents=True, exist_ok=True)
     written: List[Path] = []
 
-    merged_path = out_dir / "merged.txt"
+    merged_path = out_dir / "vpn_subscription_raw.txt"
     text = "\n".join(configs)
     merged_path.write_text(text)
     written.append(merged_path)
 
     if cfg.write_base64:
-        merged_b64 = out_dir / "merged_base64.txt"
+        merged_b64 = out_dir / "vpn_subscription_base64.txt"
         b64_content = base64.b64encode(text.encode()).decode()
         merged_b64.write_text(b64_content)
         written.append(merged_b64)
@@ -358,7 +355,7 @@ def output_files(configs: List[str], out_dir: Path, cfg: Settings) -> List[Path]
         for idx, link in enumerate(configs):
             proto = link.split("://", 1)[0].lower()
             outbounds.append({"type": proto, "tag": f"node-{idx}", "raw": link})
-        merged_singbox = out_dir / "merged_singbox.json"
+        merged_singbox = out_dir / "vpn_singbox.json"
         merged_singbox.write_text(
             json.dumps({"outbounds": outbounds}, indent=2, ensure_ascii=False)
         )
@@ -413,8 +410,8 @@ def output_files(configs: List[str], out_dir: Path, cfg: Settings) -> List[Path]
     logging.info(
         "Wrote %s%s%s%s%s%s%s",
         merged_path,
-        ", merged_base64.txt" if cfg.write_base64 else "",
-        ", merged_singbox.json" if cfg.write_singbox else "",
+        ", vpn_subscription_base64.txt" if cfg.write_base64 else "",
+        ", vpn_singbox.json" if cfg.write_singbox else "",
         ", clash.yaml" if cfg.write_clash and proxies else "",
         f", {Path(cfg.surge_file).name}" if cfg.surge_file else "",
         f", {Path(cfg.qx_file).name}" if cfg.qx_file else "",
@@ -597,10 +594,10 @@ def main() -> None:
         "--no-prune", action="store_true", help="do not remove failing sources"
     )
     parser.add_argument(
-        "--no-base64", action="store_true", help="skip merged_base64.txt"
+        "--no-base64", action="store_true", help="skip vpn_subscription_base64.txt"
     )
     parser.add_argument(
-        "--no-singbox", action="store_true", help="skip merged_singbox.json"
+        "--no-singbox", action="store_true", help="skip vpn_singbox.json"
     )
     parser.add_argument("--no-clash", action="store_true", help="skip clash.yaml")
     parser.add_argument(
@@ -703,7 +700,7 @@ def main() -> None:
         print(f"Elapsed time: {elapsed:.1f}s")
 
         if args.with_merger:
-            vpn_merger.CONFIG.resume_file = str(out_dir / "merged.txt")
+            vpn_merger.CONFIG.resume_file = str(out_dir / "vpn_subscription_raw.txt")
             buf = io.StringIO()
             with redirect_stdout(buf):
                 vpn_merger.detect_and_run()

--- a/src/massconfigmerger/source_fetcher.py
+++ b/src/massconfigmerger/source_fetcher.py
@@ -8,7 +8,7 @@ import logging
 import random
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple, Set, Callable, Awaitable
+from typing import List, Optional, Tuple, Set, Callable, Awaitable, Union, Any
 from urllib.parse import urlparse
 
 import aiohttp

--- a/tests/test_aggregation_merging.py
+++ b/tests/test_aggregation_merging.py
@@ -129,5 +129,5 @@ async def test_run_pipeline_prunes_bad_sources(aiohttp_client, tmp_path, monkeyp
         failure_threshold=1,
     )
 
-    merged = out_dir / "merged.txt"
+    merged = out_dir / "vpn_subscription_raw.txt"
     assert merged.exists()

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -10,21 +10,21 @@ from massconfigmerger.config import Settings
 def test_output_files_skip_base64(tmp_path):
     cfg = Settings(write_base64=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
-    assert (tmp_path / "merged.txt").exists()
-    assert not (tmp_path / "merged_base64.txt").exists()
+    assert (tmp_path / "vpn_subscription_raw.txt").exists()
+    assert not (tmp_path / "vpn_subscription_base64.txt").exists()
 
 
 def test_output_files_skip_singbox(tmp_path):
     cfg = Settings(write_singbox=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
-    assert (tmp_path / "merged.txt").exists()
-    assert not (tmp_path / "merged_singbox.json").exists()
+    assert (tmp_path / "vpn_subscription_raw.txt").exists()
+    assert not (tmp_path / "vpn_singbox.json").exists()
 
 
 def test_output_files_skip_clash(tmp_path):
     cfg = Settings(write_clash=False)
     aggregator_tool.output_files(["vmess://a"], tmp_path, cfg)
-    assert (tmp_path / "merged.txt").exists()
+    assert (tmp_path / "vpn_subscription_raw.txt").exists()
     assert not (tmp_path / "clash.yaml").exists()
 
 
@@ -68,9 +68,9 @@ def test_cli_flags_override(monkeypatch, tmp_path):
     aggregator_tool.main()
 
     out_dir = Path(cfg_data["output_dir"])
-    assert (out_dir / "merged.txt").exists()
-    assert not (out_dir / "merged_base64.txt").exists()
-    assert not (out_dir / "merged_singbox.json").exists()
+    assert (out_dir / "vpn_subscription_raw.txt").exists()
+    assert not (out_dir / "vpn_subscription_base64.txt").exists()
+    assert not (out_dir / "vpn_singbox.json").exists()
     assert not (out_dir / "clash.yaml").exists()
     cfg = recorded["cfg"]
     assert not cfg.write_base64
@@ -106,7 +106,10 @@ def test_cli_with_merger(monkeypatch, tmp_path):
     cfg_path = tmp_path / "c.yaml"
     cfg_path.write_text(yaml.safe_dump({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")}))
 
-    files = [tmp_path / "o" / "merged.txt", tmp_path / "o" / "merged_base64.txt"]
+    files = [
+        tmp_path / "o" / "vpn_subscription_raw.txt",
+        tmp_path / "o" / "vpn_subscription_base64.txt",
+    ]
 
     async def fake_run_pipeline(*_a, **_k):
         for f in files:
@@ -132,7 +135,10 @@ def test_cli_with_merger(monkeypatch, tmp_path):
     aggregator_tool.main()
 
     assert called == [tuple()]
-    assert aggregator_tool.vpn_merger.CONFIG.resume_file == str(tmp_path / "o" / "merged.txt")
+    assert (
+        aggregator_tool.vpn_merger.CONFIG.resume_file
+        == str(tmp_path / "o" / "vpn_subscription_raw.txt")
+    )
 
 
 def test_cli_protocols_case_insensitive(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- unify output filenames so aggregator and merger both write `vpn_subscription_*`
- update CLI help messages and README instructions
- fix tests for new names
- add missing type imports

## Testing
- `pre-commit run --files README.md src/massconfigmerger/aggregator_tool.py tests/test_output_flags.py tests/test_aggregation_merging.py`

------
https://chatgpt.com/codex/tasks/task_e_6877587f08508326b25b32eaeda88b30