### PR TITLE
Refactor CLI and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ This guide is designed for **everyone**, from absolute beginners with no coding 
 4. **Gather configuration links**
 
    ```bash
-   python aggregator_tool.py --hours 12
+   massconfigmerger fetch --hours 12
    # or
    aggregator-tool --hours 12
    # or
-   massconfigmerger fetch --hours 12
+   python aggregator_tool.py --hours 12
    ```
 
 `aggregator_tool.py` on its own creates `output/vpn_subscription_raw.txt` (plus
@@ -80,11 +80,11 @@ named by the current date.
 5. **Merge and sort the results**
 
    ```bash
-   python vpn_merger.py
+   massconfigmerger merge
    # or
    vpn-merger
    # or
-   massconfigmerger merge
+   python vpn_merger.py
    ```
 
 Use `--resume output/vpn_subscription_raw.txt` to continue a previous run without
@@ -93,11 +93,11 @@ re-downloading.
 6. **All in one step**
 
    ```bash
-   python aggregator_tool.py --with-merger
+   massconfigmerger full
    # or
    aggregator-tool --with-merger
    # or
-   massconfigmerger full
+   python aggregator_tool.py --with-merger
    ```
 
    The merger automatically runs on the freshly aggregated results using the

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,28 +12,34 @@
    pip install -e .
    ```
    Installing from PyPI works too (`pip install massconfigmerger`) and provides the `aggregator-tool`, `vpn-merger` and `vpn-retester` commands.
-3. **Run `aggregator_tool.py`** to grab fresh configuration links:
+3. **Run `massconfigmerger fetch`** to grab fresh configuration links:
    ```bash
-   python aggregator_tool.py --hours 12
+   massconfigmerger fetch --hours 12
    # or
    aggregator-tool --hours 12
+   # or
+   python aggregator_tool.py --hours 12
    ```
-4. **Run `vpn_merger.py`** to test and merge all configs:
+4. **Run `massconfigmerger merge`** to test and merge all configs:
    ```bash
-   python vpn_merger.py
+   massconfigmerger merge
    # or
    vpn-merger
+   # or
+   python vpn_merger.py
    ```
    Example output showing the new cumulative progress bar:
    ```
    🔄 [2/6] Fetching configs from 120 available sources...
    Testing: 50/120 cfg
    ```
-5. **Retest existing results** anytime with `vpn_retester.py`:
+5. **Retest existing results** anytime with `massconfigmerger retest`:
    ```bash
-   python vpn_retester.py
+   massconfigmerger retest
    # or
    vpn-retester
+   # or
+   python vpn_retester.py
    ```
 6. Import the files in `output/` into your VPN client or share the base64 link.
 

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -16,6 +16,7 @@ import json
 import logging
 import random  # noqa: F401 - used in tests for monkeypatching
 import re
+import argparse
 from datetime import datetime, timedelta
 import time
 from pathlib import Path
@@ -582,15 +583,15 @@ def setup_logging(log_dir: Path) -> None:
     )
 
 
-def main() -> None:
-    import argparse
-
-    parser = argparse.ArgumentParser(
-        description=(
-            "Mass VPN Config Aggregator. Telegram credentials are only required "
-            "when scraping Telegram or running bot mode"
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Return an argument parser configured for the aggregator tool."""
+    if parser is None:
+        parser = argparse.ArgumentParser(
+            description=(
+                "Mass VPN Config Aggregator. Telegram credentials are only required "
+                "when scraping Telegram or running bot mode"
+            )
         )
-    )
     parser.add_argument("--bot", action="store_true", help="run in telegram bot mode")
     parser.add_argument("--protocols", help="comma separated protocols to keep")
     parser.add_argument(
@@ -661,7 +662,13 @@ def main() -> None:
         action="store_true",
         help="run vpn_merger on the aggregated results using the resume feature",
     )
-    args = parser.parse_args()
+
+    return parser
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    if args is None:
+        args = build_parser().parse_args()
 
     cfg = load_config(Path(args.config))
     if args.output_dir:

--- a/src/massconfigmerger/cli.py
+++ b/src/massconfigmerger/cli.py
@@ -2,6 +2,7 @@ import sys
 import argparse
 from . import aggregator_tool
 from . import vpn_merger
+from . import vpn_retester
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -12,25 +13,28 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     fetch_p = subparsers.add_parser("fetch", help="run the aggregation pipeline")
-    fetch_p.add_argument("args", nargs=argparse.REMAINDER)
+    aggregator_tool.build_parser(fetch_p)
 
     merge_p = subparsers.add_parser("merge", help="run the VPN merger")
-    merge_p.add_argument("args", nargs=argparse.REMAINDER)
+    vpn_merger.build_parser(merge_p)
+
+    retest_p = subparsers.add_parser("retest", help="retest an existing subscription")
+    vpn_retester.build_parser(retest_p)
 
     full_p = subparsers.add_parser("full", help="aggregate then merge")
-    full_p.add_argument("args", nargs=argparse.REMAINDER)
+    aggregator_tool.build_parser(full_p)
+    full_p.set_defaults(with_merger=True)
 
     ns = parser.parse_args(argv)
 
     if ns.command == "fetch":
-        sys.argv = ["aggregator-tool"] + ns.args
-        aggregator_tool.main()
+        aggregator_tool.main(ns)
     elif ns.command == "merge":
-        sys.argv = ["vpn-merger"] + ns.args
-        vpn_merger.main()
+        vpn_merger.main(ns)
+    elif ns.command == "retest":
+        vpn_retester.main(ns)
     elif ns.command == "full":
-        sys.argv = ["aggregator-tool"] + ns.args + ["--with-merger"]
-        aggregator_tool.main()
+        aggregator_tool.main(ns)
 
 
 if __name__ == "__main__":

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -31,6 +31,7 @@ import re
 import ssl
 import sys
 import time
+import argparse
 import socket
 import json
 import base64
@@ -884,15 +885,11 @@ async def run_in_jupyter(sources_file: Optional[Union[str, Path]] = None):
     print("🔄 Running in Jupyter/async environment")
     await main_async(sources_file)
 
-def main():
-    """Main entry point with event loop detection."""
-    if sys.version_info < (3, 8):
-        print("❌ Python 3.8+ required")
-        sys.exit(1)
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Return an argument parser configured for the VPN merger."""
+    if parser is None:
+        parser = argparse.ArgumentParser(description="VPN Merger")
 
-    import argparse
-
-    parser = argparse.ArgumentParser(description="VPN Merger")
     parser.add_argument(
         "--sources",
         default=str(UnifiedSources.DEFAULT_FILE),
@@ -1002,13 +999,27 @@ def main():
         action="store_true",
         help="Show extended usage information and exit",
     )
-    args, unknown = parser.parse_known_args()
-    if args.help_extra:
-        parser.print_help()
-        print("\nFor a complete tutorial see docs/tutorial.md")
-        return 0
-    if unknown:
-        logging.warning("Ignoring unknown arguments: %s", unknown)
+
+    return parser
+
+
+def main(args: argparse.Namespace | None = None) -> int:
+    """Main entry point with event loop detection."""
+    if sys.version_info < (3, 8):
+        print("❌ Python 3.8+ required")
+        sys.exit(1)
+
+    if args is None:
+        parser = build_parser()
+        args, unknown = parser.parse_known_args()
+        if args.help_extra:
+            parser.print_help()
+            print("\nFor a complete tutorial see docs/tutorial.md")
+            return 0
+        if unknown:
+            logging.warning("Ignoring unknown arguments: %s", unknown)
+    else:
+        parser = None
 
     sources_file = args.sources
 

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -97,8 +97,11 @@ def save_results(results: List[Tuple[str, Optional[float]]], sort: bool, top_n: 
     print(f"\n✔ Retested files saved in {output_dir}/")
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Retest and sort an existing VPN subscription list")
+def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.ArgumentParser:
+    """Return an argument parser configured for the retester."""
+    if parser is None:
+        parser = argparse.ArgumentParser(description="Retest and sort an existing VPN subscription list")
+
     parser.add_argument("input", help="Path to existing raw or base64 subscription file")
     parser.add_argument("--top-n", type=int, default=0, help="Keep only the N fastest configs")
     parser.add_argument("--no-sort", action="store_true", help="Skip sorting by latency")
@@ -110,17 +113,18 @@ def main() -> None:
                         help="Discard configs slower than this ping in ms (0 disables)")
     parser.add_argument("--include-protocols", type=str, default=None,
                         help="Comma-separated protocols to include")
-    parser.add_argument(
-        "--exclude-protocols",
-        type=str,
-        default=None,
-        help="Comma-separated protocols to exclude (default: OTHER)"
-    )
+    parser.add_argument("--exclude-protocols", type=str, default=None,
+                        help="Comma-separated protocols to exclude (default: OTHER)")
     parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
                         help="Directory to save output files")
     parser.add_argument("--no-base64", action="store_true", help="Do not save base64 file")
     parser.add_argument("--no-csv", action="store_true", help="Do not save CSV report")
-    args = parser.parse_args()
+
+    return parser
+
+def main(args: argparse.Namespace | None = None) -> None:
+    if args is None:
+        args = build_parser().parse_args()
 
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
     CONFIG.test_timeout = max(0.1, args.test_timeout)


### PR DESCRIPTION
## Summary
- expose script arguments directly in `massconfigmerger` CLI
- add `build_parser` utilities and update `main` signatures
- mention massconfigmerger commands first in docs

## Testing
- `pytest -q` *(fails: UnicodeDecodeError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68776d96bcb083269471a971d34b0f0c