### PR TITLE
Improve URL extraction for subscriptions

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -59,8 +59,16 @@ HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 # Safety limit for base64 decoding to avoid huge payloads (imported from utils)
 
 def extract_subscription_urls(text: str) -> Set[str]:
-    """Return all HTTP(S) URLs in the text block."""
-    return set(HTTP_RE.findall(text))
+    """Return all HTTP(S) URLs in the text block.
+
+    Trailing punctuation such as ``)``, ``]``, ``,``, or ``.`` is stripped
+    from the matched URLs.
+    """
+
+    urls: Set[str] = set()
+    for match in HTTP_RE.findall(text):
+        urls.add(match.rstrip(")].,"))
+    return urls
 
 
 class Aggregator:

--- a/tests/test_extract_subscription_urls.py
+++ b/tests/test_extract_subscription_urls.py
@@ -1,0 +1,15 @@
+import pytest
+
+from massconfigmerger.aggregator_tool import extract_subscription_urls
+
+
+def test_extract_subscription_urls_basic():
+    text = "Visit http://example.com and https://foo.bar." \
+           " More: https://baz.qux) and http://spam.eggs], plus https://trim.com,."
+    urls = extract_subscription_urls(text)
+    assert "http://example.com" in urls
+    assert "https://foo.bar" in urls
+    assert "https://baz.qux" in urls
+    assert "http://spam.eggs" in urls
+    assert "https://trim.com" in urls
+    assert all(not u.endswith((")", "]", ",", ".")) for u in urls)


### PR DESCRIPTION
## Summary
- trim trailing punctuation when extracting HTTP(S) URLs
- test `extract_subscription_urls` with punctuation cases

## Testing
- `pytest -q tests/test_extract_subscription_urls.py tests/test_fetch_text.py tests/test_aggregation_merging.py`

------
https://chatgpt.com/codex/tasks/task_e_68777141d6e48326abe0391a1ae03e70