### PR TITLE
Add optional Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,23 @@ Key environment variables used by the compose file:
 - `MERGE_INTERVAL` – seconds between each run of `vpn_merger` (default `86400`)
 - `AGGREGATE_INTERVAL` – seconds between aggregator runs when the `aggregator` profile is enabled (default `43200`)
 
+### Flask Web Interface
+
+Install the optional `web` extras to enable a small Flask server:
+
+```bash
+pip install -e .[web]
+```
+
+Run it with:
+
+```bash
+python -m massconfigmerger.web
+```
+
+Visit `http://localhost:5000/aggregate` to run aggregation,
+`/merge` to merge the latest results and `/report` to view the last report.
+
 ### Proxy Configuration
 
 If your network requires using an HTTP or SOCKS proxy, you can provide the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dev = [
     "mypy",
     "pre-commit",
 ]
+web = [
+    "Flask",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ geoip2
 pydantic
 pydantic-settings
 tqdm
+# Optional web server
+Flask

--- a/src/massconfigmerger/web.py
+++ b/src/massconfigmerger/web.py
@@ -1,0 +1,76 @@
+"""Basic Flask server for MassConfigMerger."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from flask import Flask, render_template_string, send_file
+
+from .config import load_config
+from .aggregator_tool import run_pipeline, SOURCES_FILE, CHANNELS_FILE
+from .vpn_merger import detect_and_run
+from .result_processor import CONFIG
+
+app = Flask(__name__)
+
+CONFIG_PATH = Path("config.yaml")
+
+
+def load_cfg():
+    """Load configuration from ``CONFIG_PATH``."""
+    return load_config(CONFIG_PATH)
+
+
+def run_aggregator() -> tuple[Path, list[Path]]:
+    """Run the aggregation pipeline synchronously."""
+    cfg = load_cfg()
+    return asyncio.run(
+        run_pipeline(cfg, sources_file=SOURCES_FILE, channels_file=CHANNELS_FILE)
+    )
+
+
+def run_merger() -> None:
+    """Run the VPN merger using the latest aggregated results."""
+    cfg = load_cfg()
+    CONFIG.output_dir = cfg.output_dir
+    CONFIG.resume_file = str(Path(cfg.output_dir) / "vpn_subscription_raw.txt")
+    detect_and_run(Path(SOURCES_FILE))
+
+
+@app.route("/aggregate")
+def aggregate() -> dict:
+    out_dir, files = run_aggregator()
+    return {"output_dir": str(out_dir), "files": [str(p) for p in files]}
+
+
+@app.route("/merge")
+def merge() -> dict:
+    run_merger()
+    return {"status": "merge complete"}
+
+
+@app.route("/report")
+def report():
+    cfg = load_cfg()
+    html_report = Path(cfg.output_dir) / "vpn_report.html"
+    if html_report.exists():
+        return send_file(html_report)
+    json_report = Path(cfg.output_dir) / "vpn_report.json"
+    if not json_report.exists():
+        return "Report not found", 404
+    data = json.loads(json_report.read_text())
+    html = render_template_string(
+        "<h1>VPN Report</h1><pre>{{ data }}</pre>", data=json.dumps(data, indent=2)
+    )
+    return html
+
+
+def main() -> None:
+    """Run the Flask development server."""
+    app.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add basic Flask server exposing aggregation, merging and report endpoints
- include optional `Flask` dependency
- document running the server in README

## Testing
- `pip install Flask`
- `pytest -q` *(fails: 8 failed, 118 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68777308db5483269fa691060873f446