### PR TITLE
Add proxy options to vpn_merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Key environment variables used by the compose file:
 ### Proxy Configuration
 
 If your network requires using an HTTP or SOCKS proxy, you can provide the
-settings in two ways:
+settings in two ways (plus an override flag for the merger):
 
 1. **Environment variables** – export `HTTP_PROXY` or `SOCKS_PROXY` before
    running the scripts:
@@ -271,6 +271,13 @@ settings in two ways:
    in the placeholder `HTTP_PROXY:` or `SOCKS_PROXY:` lines. These options work
    the same as the environment variables and are useful when running behind a
    firewall.
+
+3. **Command line** – `vpn-merger` accepts `--http-proxy` or `--socks-proxy`
+   to override for a single run:
+
+   ```bash
+   vpn-merger --http-proxy http://127.0.0.1:8080
+   ```
 
 ## Advanced Features
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -34,8 +34,9 @@ retry_base_delay: 1.0
 write_base64: true
 write_singbox: true
 write_clash: true
-HTTP_PROXY:
-SOCKS_PROXY:
+# Optional proxy settings used by aggregator_tool and vpn_merger
+HTTP_PROXY: # e.g. http://127.0.0.1:8080
+SOCKS_PROXY: # e.g. socks5://127.0.0.1:1080
 
 # Merger options
 headers:


### PR DESCRIPTION
## Summary
- allow configuring HTTP_PROXY and SOCKS_PROXY in vpn_merger
- support proxies in AsyncSourceFetcher and merger network calls
- document new proxy flags

## Testing
- `flake8 .` *(fails: F401 unused imports and other style issues)*
- `pytest -q` *(fails: 9 failed, 117 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68777301badc83269bb4b8596cd8913c