### PR TITLE
Add progress display for telegram scraping

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -34,6 +34,7 @@ retry_base_delay: 1.0
 write_base64: true
 write_singbox: true
 write_clash: true
+show_progress: true
 HTTP_PROXY:
 SOCKS_PROXY:
 

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
     write_base64: bool = True
     write_singbox: bool = True
     write_clash: bool = True
+    show_progress: bool = True
     HTTP_PROXY: Optional[str] = None
     SOCKS_PROXY: Optional[str] = None
 

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -5,6 +5,7 @@ import pytest
 from massconfigmerger.vpn_merger import UltimateVPNMerger
 from massconfigmerger.result_processor import ConfigResult
 from massconfigmerger import aggregator_tool
+from massconfigmerger.config import Settings
 
 
 class DummyTqdm:


### PR DESCRIPTION
## Summary
- show progress for Telegram channel scraping
- allow disabling progress display via config
- test progress bar for Telegram scraping
- fix missing import in progress tests

## Testing
- `pytest tests/test_progress_bar.py tests/test_scrape_telegram_configs.py -q`
- `pytest -q` *(fails: Connection closed errors)*

------
https://chatgpt.com/codex/tasks/task_e_6877713523788326a0b153a401ec71ca