### PR TITLE
Add regex inclusion patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,11 @@ Use `--sort-by reliability` to rank servers by past success rates recorded in
 vpn-merger --sort-by reliability
 ```
 
+### Regex Filtering
+
+Use `--include-pattern` to keep only configs that match a regular expression.
+Combine it with `--exclude-pattern` to fine tune which servers remain.
+
 ### Huge Source List
 
 The `sources.txt` file collects links from hundreds of projects across GitHub

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -25,6 +25,7 @@ protocols:
   - hy2
   - wireguard
 exclude_patterns: []
+include_patterns: []
 output_dir: output
 log_dir: logs
 request_timeout: 10  # HTTP request timeout in seconds

--- a/docs/advanced-troubleshooting.md
+++ b/docs/advanced-troubleshooting.md
@@ -13,6 +13,7 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--include-protocols LIST` - comma-separated protocols to include (e.g. `VLESS,Reality`).
   * `--exclude-protocols LIST` - protocols to drop. By default `OTHER` is excluded; pass an empty string to keep everything.
   * `--exclude-pattern REGEX` - skip configs matching this regular expression (repeatable).
+  * `--include-pattern REGEX` - only keep configs matching this regular expression (repeatable).
   * `--resume FILE` - load a previous output file before fetching new sources.
   * `--sources FILE` - read subscription URLs from a custom file (default `sources.txt`).
   * `--output-dir DIR` - specify where output files are stored.

--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -482,6 +482,7 @@ def deduplicate_and_filter(
     if protocols:
         protocols = [p.lower() for p in protocols]
     exclude = [re.compile(p, re.IGNORECASE) for p in cfg.exclude_patterns]
+    include = [re.compile(p, re.IGNORECASE) for p in cfg.include_patterns]
     seen: Set[str] = set()
     for link in sorted(c.strip() for c in config_set):
         l_lower = link.lower()
@@ -491,6 +492,8 @@ def deduplicate_and_filter(
         if protocols and not any(l_lower.startswith(p + "://") for p in protocols):
             continue
         if any(r.search(l_lower) for r in exclude):
+            continue
+        if include and not any(r.search(l_lower) for r in include):
             continue
         if not is_valid_config(link):
 

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -7,7 +7,7 @@ import os
 import re
 
 import yaml
-from pydantic import field_validator
+from pydantic import field_validator, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
 
     protocols: List[str] = []
     exclude_patterns: List[str] = []
+    include_patterns: List[str] = Field(default_factory=list)
     output_dir: str = "output"
     log_dir: str = "logs"
     request_timeout: int = 10

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -108,6 +108,7 @@ except ImportError as exc:
 
 # Reuse global regex list from output_writer
 EXCLUDE_REGEXES: List[re.Pattern] = OUTPUT_EXCLUDE_REGEXES
+INCLUDE_REGEXES: List[re.Pattern] = []
 
 # ============================================================================
 # MAIN PROCESSOR WITH UNIFIED FUNCTIONALITY
@@ -481,6 +482,8 @@ class UltimateVPNMerger:
                 continue
             if EXCLUDE_REGEXES and any(rx.search(text) for rx in EXCLUDE_REGEXES):
                 continue
+            if INCLUDE_REGEXES and not any(rx.search(text) for rx in INCLUDE_REGEXES):
+                continue
             if CONFIG.enable_url_testing and r.ping_time is None:
                 continue
             h = self.processor.create_semantic_hash(r.config)
@@ -590,6 +593,8 @@ class UltimateVPNMerger:
                 if result.country.upper() in CONFIG.exclude_countries:
                     continue
             if EXCLUDE_REGEXES and any(r.search(text) for r in EXCLUDE_REGEXES):
+                continue
+            if INCLUDE_REGEXES and not any(r.search(text) for r in INCLUDE_REGEXES):
                 continue
             config_hash = self.processor.create_semantic_hash(result.config)
             if config_hash not in seen_hashes:
@@ -937,6 +942,11 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
         action="append",
         help="Regular expression to skip configs (can be repeated)",
     )
+    parser.add_argument(
+        "--include-pattern",
+        action="append",
+        help="Regular expression configs must match (can be repeated)",
+    )
     parser.add_argument("--resume", type=str, default=None,
                         help="Resume processing from existing raw/base64 file")
     parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
@@ -1062,8 +1072,11 @@ def main(args: argparse.Namespace | None = None) -> int:
             p.strip().upper() for p in args.exclude_protocols.split(',') if p.strip()
         }
     CONFIG.exclude_patterns = args.exclude_pattern or []
+    CONFIG.include_patterns = args.include_pattern or []
     global EXCLUDE_REGEXES
     EXCLUDE_REGEXES = [re.compile(p) for p in CONFIG.exclude_patterns]
+    global INCLUDE_REGEXES
+    INCLUDE_REGEXES = [re.compile(p) for p in CONFIG.include_patterns]
     CONFIG.resume_file = args.resume
     # Resolve and create output directory if needed
     resolved_output = Path(args.output_dir).expanduser().resolve()

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -37,6 +37,21 @@ def test_exclude_patterns_ignore_case():
     assert result == []
 
 
+def test_include_patterns():
+    link = "trojan://pw@foo.com:443"
+    other = "vmess://a"
+    cfg = Settings(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=[],
+        include_patterns=["foo"],
+    )
+    result = aggregator_tool.deduplicate_and_filter({link, other}, cfg)
+    assert result == [link]
+
+
 def test_empty_protocol_list_accepts_all():
     data = {"v": "2"}
     b64 = base64.b64encode(json.dumps(data).encode()).decode().strip("=")


### PR DESCRIPTION
## Summary
- support include-pattern regex filters via `include_patterns` setting
- update aggregator to honor the new setting
- expose `--include-pattern` option in VPN merger CLI
- document regex filtering in README and advanced troubleshooting
- add example to `config.yaml.example`
- test coverage for include_patterns

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: test_merger_seen_hash_lock_prevents_duplicates)*

------
https://chatgpt.com/codex/tasks/task_e_687779778edc83268813430e76820044