### PR TITLE
Add source shuffle option

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -178,6 +178,8 @@ class Aggregator:
         configs: Set[str] = set()
 
         source_list = list(sources)
+        if self.cfg.shuffle_sources:
+            random.shuffle(source_list)
         semaphore = asyncio.Semaphore(concurrent_limit)
 
         async def fetch_one(session: ClientSession, url: str) -> Set[str]:
@@ -655,6 +657,11 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     )
     parser.add_argument("--no-clash", action="store_true", help="skip clash.yaml")
     parser.add_argument(
+        "--shuffle-sources",
+        action="store_true",
+        help="process sources in random order",
+    )
+    parser.add_argument(
         "--output-surge",
         metavar="FILE",
         type=str,
@@ -709,6 +716,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         cfg.qx_file = args.output_qx
     if args.output_xyz is not None:
         cfg.xyz_file = args.output_xyz
+    cfg.shuffle_sources = getattr(args, "shuffle_sources", False)
 
     resolved_output = Path(cfg.output_dir).expanduser().resolve()
     resolved_output.mkdir(parents=True, exist_ok=True)

--- a/tests/test_output_flags.py
+++ b/tests/test_output_flags.py
@@ -196,3 +196,28 @@ def test_cli_output_format_flags(monkeypatch, tmp_path):
     assert (out_dir / "s.conf").exists()
     assert (out_dir / "q.conf").exists()
     assert (out_dir / "x.conf").exists()
+
+
+def test_cli_shuffle_sources(monkeypatch, tmp_path):
+    cfg_path = tmp_path / "cfg.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump({"output_dir": str(tmp_path / "o"), "log_dir": str(tmp_path / "l")})
+    )
+
+    recorded = {}
+
+    async def fake_run_pipeline(cfg, *a, **k):
+        recorded["cfg"] = cfg
+        return Path(cfg.output_dir), []
+
+    monkeypatch.setattr(aggregator_tool, "run_pipeline", fake_run_pipeline)
+    monkeypatch.setattr(aggregator_tool, "setup_logging", lambda *_: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["aggregator_tool.py", "--config", str(cfg_path), "--shuffle-sources"],
+    )
+
+    aggregator_tool.main()
+
+    assert recorded["cfg"].shuffle_sources is True


### PR DESCRIPTION
## Summary
- add `--shuffle-sources` flag to aggregator
- support randomized source order in aggregator
- test CLI handling of shuffle flag

## Testing
- `pytest -q` *(fails: test_merger_seen_hash_lock_prevents_duplicates)*

------
https://chatgpt.com/codex/tasks/task_e_68779ca728548326a8923182f26ccc49