### PR TITLE
Add usage warnings to command modules

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -40,6 +40,7 @@ from .constants import SOURCES_FILE
 from .utils import (
     is_valid_config,
     parse_configs_from_text,
+    print_public_source_warning,
 )
 
 from .config import Settings, load_config
@@ -685,6 +686,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
 
 
 def main(args: argparse.Namespace | None = None) -> None:
+    print_public_source_warning()
     if args is None:
         args = build_parser().parse_args()
 

--- a/src/massconfigmerger/cli.py
+++ b/src/massconfigmerger/cli.py
@@ -1,5 +1,6 @@
 import sys
 import argparse
+from .utils import print_public_source_warning
 from . import aggregator_tool
 from . import vpn_merger
 from . import vpn_retester
@@ -7,6 +8,7 @@ from . import vpn_retester
 
 def main(argv: list[str] | None = None) -> None:
     """Entry point for the massconfigmerger command."""
+    print_public_source_warning()
     argv = list(sys.argv[1:] if argv is None else argv)
 
     parser = argparse.ArgumentParser(prog="massconfigmerger", description="Unified interface for Mass Config Merger")

--- a/src/massconfigmerger/utils.py
+++ b/src/massconfigmerger/utils.py
@@ -15,6 +15,19 @@ from .constants import PROTOCOL_RE, BASE64_RE
 # Safety limit for base64 decoding to avoid huge payloads
 MAX_DECODE_SIZE = 256 * 1024  # 256 kB
 
+_warning_printed = False
+
+
+def print_public_source_warning() -> None:
+    """Print a usage warning once per execution."""
+    global _warning_printed
+    if not _warning_printed:
+        print(
+            "WARNING: Collected VPN nodes come from public sources. "
+            "Use at your own risk and comply with local laws."
+        )
+        _warning_printed = True
+
 
 def is_valid_config(link: str) -> bool:
     """Simple validation for known protocols."""

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -62,6 +62,7 @@ from .result_processor import (
 )
 from .output_writer import generate_comprehensive_outputs, EXCLUDE_REGEXES as OUTPUT_EXCLUDE_REGEXES
 from .clash_utils import config_to_clash_proxy, flag_emoji, build_clash_config
+from .utils import print_public_source_warning
 
 try:
     import aiohttp
@@ -1045,6 +1046,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
 
 def main(args: argparse.Namespace | None = None) -> int:
     """Main entry point with event loop detection."""
+    print_public_source_warning()
     if sys.version_info < (3, 8):
         print("❌ Python 3.8+ required")
         sys.exit(1)

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -12,6 +12,7 @@ from typing import List, Tuple, Optional
 from tqdm.asyncio import tqdm_asyncio
 
 from .vpn_merger import EnhancedConfigProcessor, CONFIG
+from .utils import print_public_source_warning
 
 
 async def _test_config(proc: EnhancedConfigProcessor, cfg: str) -> Tuple[str, Optional[float]]:
@@ -123,6 +124,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     return parser
 
 def main(args: argparse.Namespace | None = None) -> None:
+    print_public_source_warning()
     if args is None:
         args = build_parser().parse_args()
 


### PR DESCRIPTION
## Summary
- add a `print_public_source_warning` helper
- call the helper from aggregator, merger, retester, and the CLI wrapper

## Testing
- `pytest -q` *(fails: tests/test_merger_seen_hash_lock.py::test_merger_seen_hash_lock_prevents_duplicates - assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_68779c5637f88326b13886bb33752a90