### PR TITLE
Improve test setup docs

### DIFF
--- a/docs/advanced-troubleshooting.md
+++ b/docs/advanced-troubleshooting.md
@@ -91,11 +91,15 @@ New files will appear in the chosen output directory:
 
 ### Running the tests
 
-If you want to run the project's unit tests, install the package in editable
-mode with the development extras before invoking `pytest`:
+If you want to run the project's unit tests, **install the development
+dependencies first**. You can either install the package in editable mode with
+the `dev` extras or use the provided `requirements-dev.txt` file before
+invoking `pytest`:
 
 ```bash
 pip install -e .[dev]
+# or
+pip install -r requirements-dev.txt
 pytest
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,19 @@
-pytest_plugins = ["pytest_asyncio", 'aiohttp.pytest_plugin']
+"""Pytest configuration and shared fixtures."""
+
+import importlib
+import sys
+
+try:
+    importlib.import_module("pytest_asyncio")
+except ModuleNotFoundError as exc:  # pragma: no cover - only triggers when deps missing
+    message = (
+        "pytest_asyncio is required. Install dev dependencies with 'pip install -e .[dev]' "
+        "or 'pip install -r requirements-dev.txt'."
+    )
+    print(message, file=sys.stderr)
+    raise RuntimeError(message) from exc
+
+pytest_plugins = ["pytest_asyncio", "aiohttp.pytest_plugin"]
 
 import asyncio
 import pytest


### PR DESCRIPTION
## Summary
- clarify that development dependencies must be installed before running tests
- provide `pytest_asyncio` dependency hint in `conftest.py`

## Testing
- `pip install -e .[dev]`
- `pytest -q` *(fails: test_merger_seen_hash_lock_prevents_duplicates)*

------
https://chatgpt.com/codex/tasks/task_e_6877a532a5c88326b5c44179c439d2b8