### PR TITLE
Fix NodeTester resource cleanup

### DIFF
--- a/src/massconfigmerger/tester.py
+++ b/src/massconfigmerger/tester.py
@@ -104,3 +104,14 @@ class NodeTester:
             except Exception as exc:  # pragma: no cover - env specific
                 logging.debug("Resolver close failed: %s", exc)
             self.resolver = None
+
+        if self._geoip_reader is not None:
+            try:
+                close = getattr(self._geoip_reader, "close", None)
+                if asyncio.iscoroutinefunction(close):
+                    await close()  # type: ignore[misc]
+                elif callable(close):
+                    close()
+            except Exception as exc:  # pragma: no cover - env specific
+                logging.debug("GeoIP reader close failed: %s", exc)
+            self._geoip_reader = None


### PR DESCRIPTION
## Summary
- ensure NodeTester.close() cleans up geoip reader
- test geoip reader cleanup behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877a52f95788326bea05f22bd6954df