### PR TITLE
Extend NodeTester cleanup

### DIFF
--- a/src/massconfigmerger/tester.py
+++ b/src/massconfigmerger/tester.py
@@ -106,12 +106,13 @@ class NodeTester:
             self.resolver = None
 
         if self._geoip_reader is not None:
+            reader = self._geoip_reader
+            self._geoip_reader = None
             try:
-                close = getattr(self._geoip_reader, "close", None)
+                close = getattr(reader, "close", None)
                 if asyncio.iscoroutinefunction(close):
                     await close()  # type: ignore[misc]
                 elif callable(close):
                     close()
             except Exception as exc:  # pragma: no cover - env specific
                 logging.debug("GeoIP reader close failed: %s", exc)
-            self._geoip_reader = None

--- a/tests/test_merger_seen_hash_lock.py
+++ b/tests/test_merger_seen_hash_lock.py
@@ -8,21 +8,27 @@ pytest_plugins = "aiohttp.pytest_plugin"
 
 
 @pytest.mark.asyncio
-async def test_merger_seen_hash_lock_prevents_duplicates(aiohttp_client):
+async def test_merger_seen_hash_lock_prevents_duplicates():
     async def handler(request):
         return web.Response(text="vmess://abcdef0123456789abc")
 
     app = web.Application()
     app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    from aiohttp.test_utils import TestServer, TestClient
+
+    server = TestServer(app)
+    client = TestClient(server)
+    await client.start_server()
 
     merger = UltimateVPNMerger()
     merger.fetcher.session = client.session
 
+    url = str(client.make_url("/"))
     r1, r2 = await asyncio.gather(
-        merger.fetcher.fetch_source(client.make_url("/")),
-        merger.fetcher.fetch_source(client.make_url("/")),
+        merger.fetcher.fetch_source(url),
+        merger.fetcher.fetch_source(url),
     )
+    await client.close()
 
     total = len(r1[1]) + len(r2[1])
     assert total == 1


### PR DESCRIPTION
## Summary
- close GeoIP reader safely in `NodeTester.close`
- use direct aiohttp server in seen hash lock test so it runs reliably

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ad919f7c8326a7a4b037a31ba256