### PR TITLE
Graceful handling for missing config

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -19,6 +19,7 @@ import re
 import argparse
 from datetime import datetime, timedelta
 import time
+import sys
 from pathlib import Path
 from typing import Iterable, List, Set, Dict, Tuple, cast, Any
 from .clash_utils import config_to_clash_proxy, build_clash_config
@@ -703,7 +704,11 @@ def main(args: argparse.Namespace | None = None) -> None:
     if args is None:
         args = build_parser().parse_args()
 
-    cfg = load_config(Path(args.config))
+    try:
+        cfg = load_config(Path(args.config))
+    except ValueError:
+        print("Config file not found. Copy config.yaml.example to config.yaml.")
+        sys.exit(1)
     if args.output_dir:
         cfg.output_dir = args.output_dir
     if args.concurrent_limit is not None:

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -87,7 +87,7 @@ except ImportError as exc:
         "Run `pip install -r requirements.txt` before running this script."
     ) from exc
 
-from .config import Settings
+from .config import Settings, load_config
 
 
 def _choose_proxy(cfg: Settings = CONFIG) -> str | None:
@@ -1064,6 +1064,12 @@ def main(args: argparse.Namespace | None = None) -> int:
             logging.warning("Ignoring unknown arguments: %s", unknown)
     else:
         parser = None
+
+    try:
+        load_config()
+    except ValueError:
+        print("Config file not found. Copy config.yaml.example to config.yaml.")
+        sys.exit(1)
 
     sources_file = args.sources
 

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -6,6 +6,7 @@ import argparse
 import base64
 import binascii
 import csv
+import sys
 from pathlib import Path
 from typing import List, Tuple, Optional
 
@@ -13,6 +14,7 @@ from tqdm.asyncio import tqdm_asyncio
 
 from .vpn_merger import EnhancedConfigProcessor, CONFIG
 from .utils import print_public_source_warning
+from .config import load_config
 
 
 async def _test_config(proc: EnhancedConfigProcessor, cfg: str) -> Tuple[str, Optional[float]]:
@@ -127,6 +129,12 @@ def main(args: argparse.Namespace | None = None) -> None:
     print_public_source_warning()
     if args is None:
         args = build_parser().parse_args()
+
+    try:
+        load_config()
+    except ValueError:
+        print("Config file not found. Copy config.yaml.example to config.yaml.")
+        sys.exit(1)
 
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
     CONFIG.test_timeout = max(0.1, args.test_timeout)

--- a/tests/test_cli_country_flags.py
+++ b/tests/test_cli_country_flags.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 from massconfigmerger import vpn_merger
 from massconfigmerger.result_processor import CONFIG
+from massconfigmerger.config import Settings
 
 
 def test_cli_country_flags(monkeypatch, tmp_path):
@@ -13,6 +14,7 @@ def test_cli_country_flags(monkeypatch, tmp_path):
         return None
 
     monkeypatch.setattr(vpn_merger, "detect_and_run", fake_detect_and_run)
+    monkeypatch.setattr(vpn_merger, "load_config", lambda: Settings())
     monkeypatch.setattr(CONFIG, "include_countries", None)
     monkeypatch.setattr(CONFIG, "exclude_countries", None)
     monkeypatch.setattr(sys, "argv", [

--- a/tests/test_vpn_merger_no_config.py
+++ b/tests/test_vpn_merger_no_config.py
@@ -1,0 +1,16 @@
+import sys
+import pytest
+from massconfigmerger import vpn_merger
+
+
+def test_main_missing_config(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", [
+        "vpn_merger.py",
+        "--output-dir",
+        str(tmp_path),
+    ])
+    with pytest.raises(SystemExit) as exc:
+        vpn_merger.main()
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "Config file not found" in out


### PR DESCRIPTION
## Summary
- handle missing config.yaml for aggregator, merger, and retester entry points
- adjust CLI tests to mock config loading
- add regression test for vpn_merger when config.yaml is absent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b1cd4d0083269bc06f6b6e04de84