### PR TITLE
Show reliability metric in summary output

### DIFF
--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -837,6 +837,15 @@ class UltimateVPNMerger:
         else:
             success = "N/A"
         print(f"📈 Success rate: {success}")
+        if CONFIG.sort_by == "reliability":
+            total_checks = sum(h.get("total_checks", 0) for h in self.proxy_history.values())
+            successes = sum(h.get("successful_checks", 0) for h in self.proxy_history.values())
+            if total_checks:
+                avg_rel = successes / total_checks * 100
+                reliability = f"{avg_rel:.1f}% over {total_checks} checks"
+            else:
+                reliability = "N/A over 0 checks"
+            print(f"⭐ Average reliability: {reliability}")
         speed = (config_count / elapsed_time) if elapsed_time else 0
 
         rows = [

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -86,3 +86,25 @@ async def test_vpn_merger_run_summary(monkeypatch, capsys):
     assert "Sources checked: 2" in out
     assert "Configs fetched: 2" in out
     assert "Unique configs: 2" in out
+
+
+def test_print_final_summary_reliability(monkeypatch, capsys):
+    """Ensure reliability metric is shown when sorting by reliability."""
+    from massconfigmerger.result_processor import CONFIG
+    monkeypatch.setattr(CONFIG, "sort_by", "reliability")
+    merger = UltimateVPNMerger()
+    merger.proxy_history = {
+        "h1": {"successful_checks": 1, "total_checks": 2, "last_latency_ms": None, "last_seen_online_utc": None},
+        "h2": {"successful_checks": 3, "total_checks": 3, "last_latency_ms": None, "last_seen_online_utc": None},
+    }
+    stats = {
+        "protocol_stats": {},
+        "performance_stats": {},
+        "total_configs": 2,
+        "reachable_configs": 2,
+        "available_sources": 0,
+        "total_sources": 0,
+    }
+    merger._print_final_summary(2, 1.0, stats)
+    out = capsys.readouterr().out
+    assert "Average reliability: 80.0% over 5 checks" in out


### PR DESCRIPTION
## Summary
- add average reliability metric in the merger summary when sorting by reliability
- test that the reliability line is printed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b19b43a083268eaa3ff5d002b554