### PR TITLE
Handle more trailing punctuation in URL extraction

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -63,13 +63,13 @@ HTTP_RE = re.compile(r"https?://\S+", re.IGNORECASE)
 def extract_subscription_urls(text: str) -> Set[str]:
     """Return all HTTP(S) URLs in the text block.
 
-    Trailing punctuation such as ``)``, ``]``, ``,``, or ``.`` is stripped
-    from the matched URLs.
+    Trailing punctuation such as ``)``, ``]``, ``,``, ``.``, ``!``, ``?``, or ``;``
+    is stripped from the matched URLs.
     """
 
     urls: Set[str] = set()
     for match in HTTP_RE.findall(text):
-        urls.add(match.rstrip(")].,"))
+        urls.add(match.rstrip(")].,!?:;"))
     return urls
 
 

--- a/tests/test_extract_subscription_urls.py
+++ b/tests/test_extract_subscription_urls.py
@@ -13,3 +13,15 @@ def test_extract_subscription_urls_basic():
     assert "http://spam.eggs" in urls
     assert "https://trim.com" in urls
     assert all(not u.endswith((")", "]", ",", ".")) for u in urls)
+
+
+def test_extract_subscription_urls_extra_punctuation():
+    text = (
+        "Check https://foo.test! and http://bar.test? "
+        "plus https://baz.test;"
+    )
+    urls = extract_subscription_urls(text)
+    assert "https://foo.test" in urls
+    assert "http://bar.test" in urls
+    assert "https://baz.test" in urls
+    assert all(not u.endswith(("!", "?", ";")) for u in urls)


### PR DESCRIPTION
## Summary
- handle `!`, `?`, and `;` when trimming URLs in `extract_subscription_urls`
- test extraction with these punctuation marks

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b4d374b48326923e835bb838ae62