### PR TITLE
Add history-file CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ settings in two ways (plus an override flag for the merger):
 Use `--sort-by reliability` to rank servers by past success rates recorded in
 `proxy_history.json`. The file location is set by the `history_file` option in
 `config.yaml`.
+You can override it for a single run with `--history-file custom.json`.
 
 ```bash
 vpn-merger --sort-by reliability

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -204,6 +204,7 @@ vpn-merger --sort-by reliability
 ```
 Set a custom path with the `history_file` option in
 [`config.yaml.example`](../config.yaml.example).
+You can also pass `--history-file path.json` on the command line.
 
 ## 🔬 Deep Dive
 

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -144,8 +144,11 @@ class UltimateVPNMerger:
         self.last_saved_count = 0
         self._file_lock = asyncio.Lock()
         self._history_lock = asyncio.Lock()
-        # Store proxy history in output/proxy_history.json
-        self.history_path = Path(CONFIG.output_dir) / "proxy_history.json"
+        # Store proxy history in configurable location
+        hist_path = Path(CONFIG.history_file)
+        if not hist_path.is_absolute():
+            hist_path = Path(CONFIG.output_dir) / hist_path
+        self.history_path = hist_path
         self.history_path.parent.mkdir(parents=True, exist_ok=True)
         try:
             self.proxy_history = json.loads(self.history_path.read_text())
@@ -992,6 +995,12 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     parser.add_argument("--smux", type=int, default=CONFIG.smux_streams,
                         help="Set smux streams for URI configs (0=disable)")
     parser.add_argument(
+        "--history-file",
+        type=str,
+        default=None,
+        help="Path to proxy history JSON file",
+    )
+    parser.add_argument(
         "--http-proxy",
         type=str,
         default=None,
@@ -1125,6 +1134,8 @@ def main(args: argparse.Namespace | None = None) -> int:
     CONFIG.shuffle_sources = args.shuffle_sources
     CONFIG.mux_concurrency = max(0, args.mux)
     CONFIG.smux_streams = max(0, args.smux)
+    if args.history_file is not None:
+        CONFIG.history_file = args.history_file
     if args.http_proxy is not None:
         CONFIG.HTTP_PROXY = args.http_proxy
     if args.socks_proxy is not None:

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -114,6 +114,12 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
                         help="TCP connection timeout in seconds")
     parser.add_argument("--max-ping", type=int, default=0,
                         help="Discard configs slower than this ping in ms (0 disables)")
+    parser.add_argument(
+        "--history-file",
+        type=str,
+        default=None,
+        help="Path to proxy history JSON file",
+    )
     parser.add_argument("--include-protocols", type=str, default=None,
                         help="Comma-separated protocols to include")
     parser.add_argument("--exclude-protocols", type=str, default=None,
@@ -150,6 +156,8 @@ def main(args: argparse.Namespace | None = None) -> None:
             p.strip().upper() for p in args.exclude_protocols.split(',') if p.strip()
         }
     CONFIG.output_dir = str(Path(args.output_dir).expanduser())
+    if args.history_file is not None:
+        CONFIG.history_file = args.history_file
     CONFIG.write_base64 = not args.no_base64
     CONFIG.write_csv = not args.no_csv
 

--- a/tests/test_proxy_history.py
+++ b/tests/test_proxy_history.py
@@ -1,8 +1,11 @@
 import asyncio
 import json
+import sys
 from pathlib import Path
 
 from massconfigmerger.vpn_merger import UltimateVPNMerger
+from massconfigmerger import vpn_merger
+from massconfigmerger.config import Settings
 from massconfigmerger.result_processor import CONFIG
 
 
@@ -16,3 +19,30 @@ def test_proxy_history_update(tmp_path, monkeypatch):
     assert data[h]["successful_checks"] == 1
     assert data[h]["total_checks"] == 1
     assert data[h]["last_latency_ms"] == 123
+
+
+def test_cli_history_file(monkeypatch, tmp_path):
+    recorded = {}
+
+    def fake_detect_and_run(path=None):
+        merger = UltimateVPNMerger()
+        recorded["path"] = merger.history_path
+        h = merger.processor.create_semantic_hash("vmess://id@h:80")
+        asyncio.run(merger._update_history(h, True, 0.1))
+        asyncio.run(merger._save_proxy_history())
+        return None
+
+    monkeypatch.setattr(vpn_merger, "detect_and_run", fake_detect_and_run)
+    monkeypatch.setattr(vpn_merger, "load_config", lambda: Settings(output_dir=str(tmp_path)))
+    monkeypatch.setattr(sys, "argv", [
+        "vpn_merger.py",
+        "--output-dir",
+        str(tmp_path),
+        "--history-file",
+        "custom.json",
+    ])
+
+    vpn_merger.main()
+
+    assert recorded["path"] == tmp_path / "custom.json"
+    assert (tmp_path / "custom.json").exists()


### PR DESCRIPTION
## Summary
- add `--history-file` argument to VPN merger & retester
- use CONFIG.history_file in UltimateVPNMerger
- document history file CLI flag in README and tutorial
- test CLI flag creates file in the specified location

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b4d309cc8326bc449f51206891c3