### PR TITLE
Fix protocol detection case sensitivity

### DIFF
--- a/src/massconfigmerger/result_processor.py
+++ b/src/massconfigmerger/result_processor.py
@@ -198,8 +198,9 @@ class EnhancedConfigProcessor:
             "shadowtls://": "ShadowTLS",
             "brook://": "Brook",
         }
+        config_lower = config.lower()
         for prefix, protocol in protocol_map.items():
-            if config.startswith(prefix):
+            if config_lower.startswith(prefix):
                 return protocol
         return "Other"
 

--- a/tests/test_categorize_protocol.py
+++ b/tests/test_categorize_protocol.py
@@ -1,0 +1,6 @@
+def test_categorize_protocol_case_insensitive():
+    from massconfigmerger.result_processor import EnhancedConfigProcessor
+
+    proc = EnhancedConfigProcessor()
+    assert proc.categorize_protocol("VMESS://foo") == "VMess"
+    assert proc.categorize_protocol("Ss://foo") == "Shadowsocks"


### PR DESCRIPTION
## Summary
- ensure `categorize_protocol` works with uppercase schemes
- test uppercase protocol detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878058005c88326ad87cf43f527339e