### PR TITLE
Fix categorize_protocol case handling

### DIFF
--- a/src/massconfigmerger/result_processor.py
+++ b/src/massconfigmerger/result_processor.py
@@ -198,9 +198,9 @@ class EnhancedConfigProcessor:
             "shadowtls://": "ShadowTLS",
             "brook://": "Brook",
         }
-        config_lower = config.lower()
+        config = config.lower()
         for prefix, protocol in protocol_map.items():
-            if config_lower.startswith(prefix):
+            if config.startswith(prefix):
                 return protocol
         return "Other"
 

--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -58,6 +58,12 @@ def make_shadowsocksr(host="example.com", port=443):
     return f"ssr://{b64}"
 
 
+def test_categorize_protocol_uppercase():
+    proc = EnhancedConfigProcessor()
+    assert proc.categorize_protocol("VMESS://foo") == "VMess"
+    assert proc.categorize_protocol("Ss://foo") == "Shadowsocks"
+
+
 def test_create_semantic_hash_consistent_with_fragment():
     proc = EnhancedConfigProcessor()
     link1 = make_trojan(note=None)


### PR DESCRIPTION
## Summary
- normalize config before prefix matching in `categorize_protocol`
- test uppercase scheme handling in processor methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878099f4b048326b4867389e01cbee2