### PR TITLE
Add web server docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,10 @@ python -m massconfigmerger.web
 
 Visit `http://localhost:5000/aggregate` to run aggregation,
 `/merge` to merge the latest results and `/report` to view the last report.
+The aggregate route returns a JSON payload describing the output directory and
+generated files, `/merge` responds with `{"status": "merge complete"}` and
+`/report` serves the HTML or JSON report. See
+[docs/web-interface.md](docs/web-interface.md) for more details.
 
 ### Proxy Configuration
 

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -1,0 +1,27 @@
+# 🌐 Web Interface
+
+The package ships with a small Flask application that exposes a few helper routes for running the aggregator and merger from a browser or other HTTP client.
+
+## Launching the server
+
+First install the optional dependencies:
+
+```bash
+pip install massconfigmerger[web]
+```
+
+Then start the development server with:
+
+```bash
+python -m massconfigmerger.web
+```
+
+By default it listens on `http://127.0.0.1:5000`. Use Flask's `--host` and `--port` options if you need to bind to a different address.
+
+## Available endpoints
+
+- `GET /aggregate` – run the aggregation pipeline. Returns JSON with the output directory and list of generated files.
+- `GET /merge` – merge the most recent results. Responds with `{"status": "merge complete"}` when done.
+- `GET /report` – download `vpn_report.html` if present, otherwise render the JSON report inline.
+
+These routes are intentionally simple and return minimal information, making them suitable for automation or quick checks from a web browser.

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1,0 +1,52 @@
+import pytest
+
+flask = pytest.importorskip("flask")
+
+from massconfigmerger import web
+from massconfigmerger.config import Settings
+
+
+def test_aggregate_endpoint(monkeypatch, tmp_path):
+    def fake_run():
+        return tmp_path, [tmp_path / "a.txt"]
+
+    monkeypatch.setattr(web, "run_aggregator", fake_run)
+
+    with web.app.test_client() as client:
+        res = client.get("/aggregate")
+
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data == {
+        "output_dir": str(tmp_path),
+        "files": [str(tmp_path / "a.txt")],
+    }
+
+
+def test_merge_endpoint(monkeypatch):
+    called = {}
+
+    def fake_run():
+        called["ok"] = True
+
+    monkeypatch.setattr(web, "run_merger", fake_run)
+
+    with web.app.test_client() as client:
+        res = client.get("/merge")
+
+    assert res.status_code == 200
+    assert res.get_json() == {"status": "merge complete"}
+    assert called.get("ok")
+
+
+def test_report_endpoint_html(monkeypatch, tmp_path):
+    html = tmp_path / "vpn_report.html"
+    html.write_text("<h1>Report</h1>")
+
+    monkeypatch.setattr(web, "load_cfg", lambda: Settings(output_dir=str(tmp_path)))
+
+    with web.app.test_client() as client:
+        res = client.get("/report")
+
+    assert res.status_code == 200
+    assert b"Report" in res.data


### PR DESCRIPTION
## Summary
- document Flask web interface in README and new doc
- add basic tests for web routes using Flask test client

## Testing
- `pre-commit run --files docs/web-interface.md README.md tests/test_web_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_687809c63be083269c82f910cf2a7533