### PR TITLE
Use connect_timeout for NodeTester

### DIFF
--- a/docs/advanced-troubleshooting.md
+++ b/docs/advanced-troubleshooting.md
@@ -17,7 +17,7 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--resume FILE` - load a previous output file before fetching new sources.
   * `--sources FILE` - read subscription URLs from a custom file (default `sources.txt`).
   * `--output-dir DIR` - specify where output files are stored.
-  * `--test-timeout SEC` - adjust connection test timeout.
+  * `--test-timeout SEC` - adjust connection test timeout (sets `connect_timeout`).
   * `--cumulative-batches` - make each batch cumulative instead of standalone.
   * `--no-strict-batch` - don't split strictly by `--save-every`, just trigger when exceeded.
   * `--shuffle-sources` - randomize source processing order.
@@ -50,7 +50,7 @@ If you have your own subscription links you'd like to merge, edit `sources.txt`:
 If you already generated a subscription file, run `python vpn_retester.py <path>` to check all servers again and sort them by current latency. The script accepts raw or base64 files and now exposes several tuning options:
 
 * `--concurrent-limit` limit how many tests run in parallel
-* `--test-timeout` set the connection timeout in seconds
+* `--test-timeout` set the connection timeout in seconds (stored in `connect_timeout`)
 * `--max-ping` drop configs slower than this ping (ms)
 * `--include-protocols` or `--exclude-protocols` filter by protocol (default drops `OTHER`)
 * `--output-dir` choose where results are written

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -131,7 +131,7 @@ aggregator run.
 | **MUX/SMUX Tuning** | `--mux` and `--smux` modify connection multiplexing. | Improve throughput with modern clients. |
 | **Resume from File** | `--resume` loads a previous raw/base64 output before fetching. | Continue a crashed run without starting over. |
 | **Custom Output Dir** | Use `--output-dir` to choose where files are saved. | Organize results anywhere you like. |
-| **Set Test Timeout** | Tune connection checks with `--test-timeout`. | Useful for slow or distant servers. |
+| **Set Test Timeout** | Tune connection checks with `connect_timeout` or `--test-timeout`. | Useful for slow or distant servers. |
 | **Disable Features** | Flags `--no-url-test`, `--no-sort`, `--no-base64` and `--no-csv` give full control. | Skip slow checks or extra files when not needed. |
 | **Max Ping Filter** | Remove configs with latency above `--max-ping` ms. | Keep only fast servers for gaming or streaming. |
 | **Concurrent Limit / Retries** | Tweak network load with `--concurrent-limit` and `--max-retries`. | Prevent crashes on slow networks or strict hosts. |

--- a/src/massconfigmerger/tester.py
+++ b/src/massconfigmerger/tester.py
@@ -55,7 +55,7 @@ class NodeTester:
 
             _, writer = await asyncio.wait_for(
                 asyncio.open_connection(target, port),
-                timeout=self.config.test_timeout,
+                timeout=self.config.connect_timeout,
             )
             writer.close()
             await writer.wait_closed()

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -959,7 +959,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
                         help="Resume processing from existing raw/base64 file")
     parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
                         help="Directory to save output files")
-    parser.add_argument("--test-timeout", type=float, default=CONFIG.test_timeout,
+    parser.add_argument("--test-timeout", type=float, default=CONFIG.connect_timeout,
                         help="TCP connection test timeout in seconds")
     parser.add_argument("--no-url-test", action="store_true",
                         help="Disable server reachability testing")
@@ -1112,7 +1112,7 @@ def main(args: argparse.Namespace | None = None) -> int:
     resolved_output = Path(args.output_dir).expanduser().resolve()
     resolved_output.mkdir(parents=True, exist_ok=True)
     CONFIG.output_dir = str(resolved_output)
-    CONFIG.test_timeout = max(0.1, args.test_timeout)
+    CONFIG.connect_timeout = max(0.1, args.test_timeout)
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
     CONFIG.max_retries = max(1, args.max_retries)
     CONFIG.max_ping_ms = args.max_ping if args.max_ping > 0 else None

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -110,7 +110,7 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     parser.add_argument("--no-sort", action="store_true", help="Skip sorting by latency")
     parser.add_argument("--concurrent-limit", type=int, default=CONFIG.concurrent_limit,
                         help="Number of concurrent tests")
-    parser.add_argument("--test-timeout", type=float, default=CONFIG.test_timeout,
+    parser.add_argument("--test-timeout", type=float, default=CONFIG.connect_timeout,
                         help="TCP connection timeout in seconds")
     parser.add_argument("--max-ping", type=int, default=0,
                         help="Discard configs slower than this ping in ms (0 disables)")
@@ -143,7 +143,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         sys.exit(1)
 
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
-    CONFIG.test_timeout = max(0.1, args.test_timeout)
+    CONFIG.connect_timeout = max(0.1, args.test_timeout)
     CONFIG.max_ping_ms = args.max_ping if args.max_ping > 0 else None
     if args.include_protocols:
         CONFIG.include_protocols = {p.strip().upper() for p in args.include_protocols.split(',') if p.strip()}


### PR DESCRIPTION
## Summary
- use `connect_timeout` for NodeTester connection attempts
- let `--test-timeout` update `connect_timeout`
- document new behaviour in docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687809a64fd48326a209c3b1bf00c5a3