### PR TITLE
Reuse persistent aiohttp session

### DIFF
--- a/tests/test_async_source_fetcher.py
+++ b/tests/test_async_source_fetcher.py
@@ -22,8 +22,7 @@ async def test_fetch_source_retries_on_error(aiohttp_client, monkeypatch):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
-    fetcher.session = client.session
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
 
     monkeypatch.setattr(CONFIG, "max_retries", 3)
     url, results = await fetcher.fetch_source(client.make_url("/"))
@@ -43,8 +42,7 @@ async def test_fetch_source_timeout(aiohttp_client, monkeypatch):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
-    fetcher.session = client.session
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
 
     monkeypatch.setattr(CONFIG, "request_timeout", 0.01)
     monkeypatch.setattr(CONFIG, "max_retries", 1)
@@ -63,8 +61,7 @@ async def test_seen_hash_lock_prevents_duplicates(aiohttp_client):
     client = await aiohttp_client(app)
 
     seen = set()
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), seen)
-    fetcher.session = client.session
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, session=client.session)
 
     r1, r2 = await asyncio.gather(
         fetcher.fetch_source(client.make_url("/")),
@@ -86,10 +83,8 @@ async def test_shared_lock_across_instances(aiohttp_client):
 
     seen = set()
     lock = asyncio.Lock()
-    f1 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock)
-    f2 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock)
-    f1.session = client.session
-    f2.session = client.session
+    f1 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock, session=client.session)
+    f2 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock, session=client.session)
 
     r1, r2 = await asyncio.gather(
         f1.fetch_source(client.make_url("/")),
@@ -110,8 +105,7 @@ async def test_fetch_source_concurrent_execution(aiohttp_client):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
-    fetcher.session = client.session
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
 
     start = asyncio.get_event_loop().time()
     await asyncio.gather(
@@ -133,8 +127,7 @@ async def test_source_availability_concurrent_execution(aiohttp_client):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
-    fetcher.session = client.session
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
 
     start = asyncio.get_event_loop().time()
     await asyncio.gather(

--- a/tests/test_merger_seen_hash_lock.py
+++ b/tests/test_merger_seen_hash_lock.py
@@ -21,7 +21,9 @@ async def test_merger_seen_hash_lock_prevents_duplicates():
     await client.start_server()
 
     merger = UltimateVPNMerger()
+    await merger.fetcher.close()
     merger.fetcher.session = client.session
+    merger.fetcher._own_session = False
 
     url = str(client.make_url("/"))
     r1, r2 = await asyncio.gather(


### PR DESCRIPTION
## Summary
- open persistent ClientSession in `AsyncSourceFetcher`
- close the session when done
- adjust `UltimateVPNMerger` to use the new close method
- update tests for new lifecycle

## Testing
- `pre-commit run --files src/massconfigmerger/source_fetcher.py src/massconfigmerger/vpn_merger.py tests/test_async_source_fetcher.py tests/test_merger_seen_hash_lock.py`

------
https://chatgpt.com/codex/tasks/task_e_687809a0d8b88326833055e22501781b