### PR TITLE
Case-insensitive protocol categorization

### DIFF
--- a/docs/protocol-deep-dive.md
+++ b/docs/protocol-deep-dive.md
@@ -20,6 +20,8 @@ Each server link is classified into a protocol type. By default the merger only 
 
 Some VPN clients may not recognise every item in this list, and other clients might support additional protocols that are omitted here. Use `--include-protocols` if you need to expand it.
 
+Protocol matching is **case-insensitive**, so links such as `VMESS://example` are treated the same as `vmess://example`.
+
 -----
 
 ### Protocol Comparison

--- a/src/massconfigmerger/result_processor.py
+++ b/src/massconfigmerger/result_processor.py
@@ -180,7 +180,11 @@ class EnhancedConfigProcessor:
         return await self.tester.lookup_country(host)
 
     def categorize_protocol(self, config: str) -> str:
-        """Categorize configuration by protocol."""
+        """Categorize configuration by protocol.
+
+        Matching is case-insensitive so schemes like ``VMESS://`` work the same
+        as ``vmess://``.
+        """
         protocol_map = {
             "vmess://": "VMess",
             "vless://": "VLESS",
@@ -198,9 +202,9 @@ class EnhancedConfigProcessor:
             "shadowtls://": "ShadowTLS",
             "brook://": "Brook",
         }
-        config = config.lower()
+        config_lower = config.lower()
         for prefix, protocol in protocol_map.items():
-            if config.startswith(prefix):
+            if config_lower.startswith(prefix):
                 return protocol
         return "Other"
 

--- a/tests/test_categorize_protocol.py
+++ b/tests/test_categorize_protocol.py
@@ -4,3 +4,5 @@ def test_categorize_protocol_case_insensitive():
     proc = EnhancedConfigProcessor()
     assert proc.categorize_protocol("VMESS://foo") == "VMess"
     assert proc.categorize_protocol("Ss://foo") == "Shadowsocks"
+    assert proc.categorize_protocol("VLESS://foo") == "VLESS"
+    assert proc.categorize_protocol("WIREGUARD://foo") == "WireGuard"

--- a/tests/test_processor_methods.py
+++ b/tests/test_processor_methods.py
@@ -62,6 +62,8 @@ def test_categorize_protocol_uppercase():
     proc = EnhancedConfigProcessor()
     assert proc.categorize_protocol("VMESS://foo") == "VMess"
     assert proc.categorize_protocol("Ss://foo") == "Shadowsocks"
+    assert proc.categorize_protocol("TROJAN://foo") == "Trojan"
+    assert proc.categorize_protocol("HYSTERIA://foo") == "Hysteria"
 
 
 def test_create_semantic_hash_consistent_with_fragment():


### PR DESCRIPTION
## Summary
- lowercase config strings before categorization
- clarify case-insensitive behaviour in result processor docs
- document case-insensitive protocol matching
- extend tests with additional uppercase protocol cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687809a81eb4832684ff3ecf11912184