### PR TITLE
Atomic aggregator output

### DIFF
--- a/tests/test_aggregation_merging.py
+++ b/tests/test_aggregation_merging.py
@@ -105,6 +105,29 @@ async def test_aggregator_output_files_atomic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_aggregator_output_files_concurrent(tmp_path):
+    cfg = Settings(
+        output_dir=str(tmp_path),
+        write_base64=False,
+        write_singbox=False,
+        write_clash=False,
+    )
+
+    async def call():
+        await asyncio.to_thread(
+            aggregator_tool.Aggregator.output_files,
+            ["vmess://uuid@host:80"],
+            tmp_path,
+            cfg,
+        )
+
+    await asyncio.gather(call(), call())
+
+    assert (tmp_path / "vpn_subscription_raw.txt").exists()
+    assert not any(p.suffix == ".tmp" for p in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
 async def test_run_pipeline_prunes_bad_sources(aiohttp_client, tmp_path, monkeypatch):
     async def good(request):
         return web.Response(text="vless://user@host:80")


### PR DESCRIPTION
## Summary
- ensure aggregator output files use temporary names with `Path.replace` semantics
- test concurrent calls to `output_files`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687817eb507c83269bbc7e8391a1f6d9