### PR TITLE
Maintain shared ClientSession

### DIFF
--- a/tests/test_async_source_fetcher.py
+++ b/tests/test_async_source_fetcher.py
@@ -22,7 +22,7 @@ async def test_fetch_source_retries_on_error(aiohttp_client, monkeypatch):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
 
     monkeypatch.setattr(CONFIG, "max_retries", 3)
     url, results = await fetcher.fetch_source(client.make_url("/"))
@@ -42,7 +42,7 @@ async def test_fetch_source_timeout(aiohttp_client, monkeypatch):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
 
     monkeypatch.setattr(CONFIG, "request_timeout", 0.01)
     monkeypatch.setattr(CONFIG, "max_retries", 1)
@@ -61,7 +61,7 @@ async def test_seen_hash_lock_prevents_duplicates(aiohttp_client):
     client = await aiohttp_client(app)
 
     seen = set()
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, session=client.session)
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), seen)
 
     r1, r2 = await asyncio.gather(
         fetcher.fetch_source(client.make_url("/")),
@@ -83,8 +83,8 @@ async def test_shared_lock_across_instances(aiohttp_client):
 
     seen = set()
     lock = asyncio.Lock()
-    f1 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock, session=client.session)
-    f2 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock, session=client.session)
+    f1 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock)
+    f2 = AsyncSourceFetcher(EnhancedConfigProcessor(), seen, lock)
 
     r1, r2 = await asyncio.gather(
         f1.fetch_source(client.make_url("/")),
@@ -105,7 +105,7 @@ async def test_fetch_source_concurrent_execution(aiohttp_client):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
 
     start = asyncio.get_event_loop().time()
     await asyncio.gather(
@@ -127,7 +127,7 @@ async def test_source_availability_concurrent_execution(aiohttp_client):
     app.router.add_get("/", handler)
     client = await aiohttp_client(app)
 
-    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set(), session=client.session)
+    fetcher = AsyncSourceFetcher(EnhancedConfigProcessor(), set())
 
     start = asyncio.get_event_loop().time()
     await asyncio.gather(

--- a/tests/test_merger_seen_hash_lock.py
+++ b/tests/test_merger_seen_hash_lock.py
@@ -21,9 +21,6 @@ async def test_merger_seen_hash_lock_prevents_duplicates():
     await client.start_server()
 
     merger = UltimateVPNMerger()
-    await merger.fetcher.close()
-    merger.fetcher.session = client.session
-    merger.fetcher._own_session = False
 
     url = str(client.make_url("/"))
     r1, r2 = await asyncio.gather(


### PR DESCRIPTION
## Summary
- keep one ClientSession for AsyncSourceFetcher
- simplify session handling in fetcher
- adjust async fetcher tests for new lifecycle
- update merger lock test to rely on built-in session

## Testing
- `pre-commit run --files src/massconfigmerger/source_fetcher.py tests/test_async_source_fetcher.py tests/test_merger_seen_hash_lock.py`

------
https://chatgpt.com/codex/tasks/task_e_687819c936048326902ca0fdd8400f4a