### PR TITLE
Clarify optional extras and pin pydantic

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,15 @@ Key environment variables used by the compose file:
 - `MERGE_INTERVAL` – seconds between each run of `vpn_merger` (default `86400`)
 - `AGGREGATE_INTERVAL` – seconds between aggregator runs when the `aggregator` profile is enabled (default `43200`)
 
+### Optional Extras
+
+The project defines a couple of [extras](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-extras) for optional features:
+
+- `dev` – installs the testing tools and linters needed for development (`pytest`, `mypy`, `flake8`, etc.).
+- `web` – installs the minimal Flask-based web interface. No FastAPI dependency is required.
+
+Install them with `pip install -e .[dev]` or `pip install -e .[web]` as needed.
+
 ### Flask Web Interface
 
 Install the optional `web` extras to enable a small Flask server:

--- a/docs/web-interface.md
+++ b/docs/web-interface.md
@@ -6,6 +6,7 @@ The package ships with a small Flask application that exposes a few helper route
 
 First install the optional dependencies:
 
+This extra installs only Flask and avoids FastAPI entirely, so it works with the default Pydantic 2 dependencies.
 ```bash
 pip install massconfigmerger[web]
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "telethon",
     "PyYAML",
     "geoip2",
-    "pydantic",
+    "pydantic>=2",
     "pydantic-settings",
     "tqdm",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ nest-asyncio
 telethon
 PyYAML
 geoip2
-pydantic
+pydantic>=2
 pydantic-settings
 tqdm
 # Optional web server


### PR DESCRIPTION
## Summary
- describe optional extras in README
- mention Flask-only web extra in docs
- pin pydantic>=2 in project metadata and requirements

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68781cc5a5408326b58f4385ed57b2c4