### PR TITLE
Refactor aggregator session handling

### DIFF
--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -81,7 +81,14 @@ async def test_fetch_and_parse_configs_progress(monkeypatch):
     monkeypatch.setattr("massconfigmerger.aggregator_tool.fetch_text", fake_fetch_text)
 
     agg = aggregator_tool.Aggregator(Settings())
-    configs = await agg.fetch_and_parse_configs(["u1", "u2"])
+
+    async with aggregator_tool.aiohttp.ClientSession() as sess:
+        monkeypatch.setattr(
+            aggregator_tool.aiohttp,
+            "ClientSession",
+            lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not be called")),
+        )
+        configs = await agg.fetch_and_parse_configs(["u1", "u2"], session=sess)
 
     assert configs == {"vmess://cfg"}
     bar = bars[0]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -8,10 +8,10 @@ from massconfigmerger.config import Settings
 
 @pytest.mark.asyncio
 async def test_run_pipeline_prints_summary(monkeypatch, capsys, tmp_path):
-    async def fake_check(*_a, **_k):
+    async def fake_check(*args, **kwargs):
         return ["s1", "s2"]
 
-    async def fake_fetch(*_a, **_k):
+    async def fake_fetch(*args, **kwargs):
         return {"vmess://a", "vmess://b"}
 
     async def fake_scrape(*_a, **_k):


### PR DESCRIPTION
## Summary
- allow `Aggregator.check_and_update_sources` and `fetch_and_parse_configs` to reuse an existing aiohttp session
- open a single session in `Aggregator.run` and pass it to the helpers
- update tests for the new parameter

## Testing
- `pre-commit run --files src/massconfigmerger/aggregator_tool.py tests/test_check_sources.py tests/test_progress_bar.py tests/test_summary.py`

------
https://chatgpt.com/codex/tasks/task_e_68781cfc08388326917b2489bbc994c9