### PR TITLE
Add GitHub Gist upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,14 @@ Use `--include-pattern` to keep only configs that match a regular expression.
 Combine it with `--exclude-pattern` to fine tune which servers remain. These
 flags work with both `vpn-merger` and `aggregator-tool`.
 
+### GitHub Gist Upload
+
+Use `--upload-gist` with either `vpn-merger` or `aggregator-tool` to automatically
+upload the generated files to a private GitHub Gist. Provide a token with the
+`gist` scope via the `github_token` setting in `config.yaml` or the
+`GITHUB_TOKEN` environment variable. After uploading, the raw URLs are saved in
+`output/upload_links.txt` for quick reference.
+
 ### Huge Source List
 
 The `sources.txt` file collects links from hundreds of projects across GitHub

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     write_clash: bool = True
     HTTP_PROXY: Optional[str] = None
     SOCKS_PROXY: Optional[str] = None
+    github_token: Optional[str] = None
 
     # Merger settings
     headers: Dict[str, str] = {

--- a/tests/test_gist_upload.py
+++ b/tests/test_gist_upload.py
@@ -1,0 +1,29 @@
+import asyncio
+from pathlib import Path
+from aiohttp import web
+import pytest
+
+from massconfigmerger.output_writer import upload_files_to_gist, write_upload_links
+
+
+@pytest.mark.asyncio
+async def test_upload_files_to_gist(aiohttp_client, tmp_path):
+    f = tmp_path / "vpn_subscription_raw.txt"
+    f.write_text("data", encoding="utf-8")
+
+    async def handler(request):
+        assert request.headers.get("Authorization") == "token secret"
+        payload = await request.json()
+        filename = next(iter(payload["files"]))
+        return web.json_response({"files": {filename: {"raw_url": f"https://gist/{filename}"}}})
+
+    app = web.Application()
+    app.router.add_post("/gists", handler)
+    client = await aiohttp_client(app)
+
+    base = str(client.server.make_url(""))
+    links = await upload_files_to_gist([f], "secret", base_url=base)
+    assert links == {f.name: f"https://gist/{f.name}"}
+
+    path = write_upload_links(links, tmp_path)
+    assert path.read_text().strip() == f"{f.name}: https://gist/{f.name}"


### PR DESCRIPTION
## Summary
- add `upload_files_to_gist` and `write_upload_links` utilities
- support github_token config option
- add `--upload-gist` flag to CLI tools
- document gist uploads in README
- unit test gist upload logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782904202083268a62bf7285eb1a31