### PR TITLE
Centralize MAX_DECODE_SIZE constant

### DIFF
--- a/src/massconfigmerger/constants.py
+++ b/src/massconfigmerger/constants.py
@@ -14,3 +14,6 @@ PROTOCOL_RE = re.compile(
     re.IGNORECASE,
 )
 BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
+
+# Safety limit for base64 decoding to avoid huge payloads
+MAX_DECODE_SIZE = 256 * 1024  # 256 kB

--- a/src/massconfigmerger/result_processor.py
+++ b/src/massconfigmerger/result_processor.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlparse, parse_qs, urlencode, urlunparse, parse_qsl
 
 from .config import Settings, load_config
+from .constants import MAX_DECODE_SIZE as GLOBAL_MAX_DECODE_SIZE
 from .tester import NodeTester
 
 DEFAULT_CONFIG_FILE = Path(__file__).resolve().with_name("config.yaml")
@@ -38,7 +39,7 @@ class ConfigResult:
 class EnhancedConfigProcessor:
     """Advanced configuration processor with comprehensive testing capabilities."""
 
-    MAX_DECODE_SIZE = 256 * 1024  # 256 kB safety limit for base64 payloads
+    MAX_DECODE_SIZE = GLOBAL_MAX_DECODE_SIZE
 
     def __init__(self) -> None:
         self.tester = NodeTester(CONFIG)

--- a/src/massconfigmerger/source_fetcher.py
+++ b/src/massconfigmerger/source_fetcher.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import aiohttp
 from tqdm import tqdm
 
-from .constants import SOURCES_FILE
+from .constants import SOURCES_FILE, MAX_DECODE_SIZE
 from .result_processor import CONFIG, EnhancedConfigProcessor, ConfigResult
 from . import get_client_loop
 
@@ -28,7 +28,6 @@ PROTOCOL_RE = re.compile(
     re.IGNORECASE,
 )
 BASE64_RE = re.compile(r"^[A-Za-z0-9+/=_-]+$")
-MAX_DECODE_SIZE = 256 * 1024  # 256 kB
 
 
 async def fetch_text(

--- a/src/massconfigmerger/utils.py
+++ b/src/massconfigmerger/utils.py
@@ -12,10 +12,7 @@ from typing import Set
 
 from .config import Settings
 
-from .constants import PROTOCOL_RE, BASE64_RE
-
-# Safety limit for base64 decoding to avoid huge payloads
-MAX_DECODE_SIZE = 256 * 1024  # 256 kB
+from .constants import PROTOCOL_RE, BASE64_RE, MAX_DECODE_SIZE
 
 _warning_printed = False
 

--- a/tests/test_parse_configs.py
+++ b/tests/test_parse_configs.py
@@ -1,6 +1,7 @@
 import base64
 
 from massconfigmerger import utils
+from massconfigmerger.constants import MAX_DECODE_SIZE
 
 
 def test_multiple_links_same_line():
@@ -38,7 +39,7 @@ def test_extract_all_protocols():
 
 
 def test_parse_oversized_line(caplog):
-    big_line = "A" * (utils.MAX_DECODE_SIZE + 1)
+    big_line = "A" * (MAX_DECODE_SIZE + 1)
     with caplog.at_level('DEBUG'):
         result = utils.parse_configs_from_text(big_line)
     assert result == set()


### PR DESCRIPTION
## Summary
- define `MAX_DECODE_SIZE` once in `constants.py`
- import it in `source_fetcher`, `utils` and `EnhancedConfigProcessor`
- update tests to use the new constant location

## Testing
- `pre-commit run --files src/massconfigmerger/constants.py src/massconfigmerger/utils.py src/massconfigmerger/source_fetcher.py src/massconfigmerger/result_processor.py tests/test_parse_configs.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782e5f091c8326887f48f588f19642