### PR TITLE
Add semantic deduplication

### DIFF
--- a/src/massconfigmerger/aggregator_tool.py
+++ b/src/massconfigmerger/aggregator_tool.py
@@ -47,6 +47,7 @@ from .utils import (
     print_public_source_warning,
     choose_proxy,
 )
+from .result_processor import EnhancedConfigProcessor
 
 from .config import Settings, load_config
 
@@ -522,12 +523,14 @@ def deduplicate_and_filter(
         protocols = [p.lower() for p in protocols]
     exclude = [re.compile(p, re.IGNORECASE) for p in cfg.exclude_patterns]
     include = [re.compile(p, re.IGNORECASE) for p in cfg.include_patterns]
+    processor = EnhancedConfigProcessor()
     seen: Set[str] = set()
     for link in sorted(c.strip() for c in config_set):
         l_lower = link.lower()
-        if l_lower in seen:
+        link_hash = processor.create_semantic_hash(link)
+        if link_hash in seen:
             continue
-        seen.add(l_lower)
+        seen.add(link_hash)
         if protocols and not any(l_lower.startswith(p + "://") for p in protocols):
             continue
         if any(r.search(l_lower) for r in exclude):

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -98,3 +98,26 @@ def test_protocol_filter_mixed_case_argument():
     )
     result = aggregator_tool.deduplicate_and_filter({vmess, trojan}, cfg, ["VMeSS"])
     assert result == [vmess]
+
+
+def test_semantic_deduplication_vmess():
+    """Links representing the same VMess config should deduplicate."""
+    data = {"v": "2", "add": "host", "port": "80", "id": "uuid"}
+    json1 = json.dumps(data)
+    b64_1 = base64.b64encode(json1.encode()).decode().strip("=")
+    link1 = f"vmess://{b64_1}"
+
+    json2 = json.dumps({"id": "uuid", "port": "80", "add": "host", "v": "2"})
+    b64_2 = base64.b64encode(json2.encode()).decode().strip("=")
+    link2 = f"VMESS://{b64_2}"
+
+    cfg = Settings(
+        telegram_api_id=1,
+        telegram_api_hash="h",
+        telegram_bot_token="t",
+        allowed_user_ids=[1],
+        protocols=["vmess"],
+    )
+    result = aggregator_tool.deduplicate_and_filter({link1, link2}, cfg)
+    assert len(result) == 1
+    assert result[0] in {link1, link2}


### PR DESCRIPTION
## Summary
- use `EnhancedConfigProcessor` to dedupe configs semantically
- ensure deduplication uses semantic hash
- test deduplication of equivalent VMess links

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68782fadaf2c8326982e8691cd89e48c