### PR TITLE
Remove obsolete test_timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ recorded in `sources_disabled.txt`. Advanced users can change the limit with
 ## FAQ
 
 ### Why does the script take so long?
-The merger checks hundreds of servers. Reduce the number of sources or use a smaller `--concurrent-limit`. Skipping tests with `--no-url-test` can also speed up runs.
+The merger checks hundreds of servers. Reduce the number of sources or use a smaller `--concurrent-limit`. Skipping tests with `--no-url-test` can also speed up runs. If connections often fail, increase the `--connect-timeout` value.
 
 ### There is no output directory
 Ensure you ran the script in this repository and watch for errors. Results are saved in the `output/` folder or the location given by `--output-dir`.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -76,7 +76,6 @@ valid_prefixes:
   - h2://
 enable_url_testing: true
 enable_sorting: true
-test_timeout: 5.0
 save_every: 1000
 stop_after_found: 0
 top_n: 0

--- a/docs/advanced-troubleshooting.md
+++ b/docs/advanced-troubleshooting.md
@@ -21,7 +21,7 @@ Run `python vpn_merger.py --help` to see all options. Important flags include:
   * `--resume FILE` - load a previous output file before fetching new sources.
   * `--sources FILE` - read subscription URLs from a custom file (default `sources.txt`).
   * `--output-dir DIR` - specify where output files are stored.
-  * `--test-timeout SEC` - adjust connection test timeout (sets `connect_timeout`).
+  * `--connect-timeout SEC` - adjust connection test timeout (sets `connect_timeout`).
   * `--cumulative-batches` - make each batch cumulative instead of standalone.
   * `--no-strict-batch` - don't split strictly by `--save-every`, just trigger when exceeded.
   * `--shuffle-sources` - randomize source processing order.
@@ -54,7 +54,7 @@ If you have your own subscription links you'd like to merge, edit `sources.txt`:
 If you already generated a subscription file, run `python vpn_retester.py <path>` to check all servers again and sort them by current latency. The script accepts raw or base64 files and now exposes several tuning options:
 
 * `--concurrent-limit` limit how many tests run in parallel
-* `--test-timeout` set the connection timeout in seconds (stored in `connect_timeout`)
+* `--connect-timeout` set the connection timeout in seconds (stored in `connect_timeout`)
 * `--max-ping` drop configs slower than this ping (ms)
 * `--include-protocols` or `--exclude-protocols` filter by protocol (default drops `OTHER`)
 * `--output-dir` choose where results are written
@@ -65,7 +65,7 @@ Example:
 ```bash
 python vpn_retester.py output/vpn_subscription_raw.txt \
   --include-protocols VLESS,REALITY --max-ping 250 \
-  --concurrent-limit 20 --test-timeout 3 --output-dir retested --no-base64
+  --concurrent-limit 20 --connect-timeout 3 --output-dir retested --no-base64
 ```
 
 New files will appear in the chosen output directory:

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -131,7 +131,7 @@ aggregator run.
 | **MUX/SMUX Tuning** | `--mux` and `--smux` modify connection multiplexing. | Improve throughput with modern clients. |
 | **Resume from File** | `--resume` loads a previous raw/base64 output before fetching. | Continue a crashed run without starting over. |
 | **Custom Output Dir** | Use `--output-dir` to choose where files are saved. | Organize results anywhere you like. |
-| **Set Test Timeout** | Tune connection checks with `connect_timeout` or `--test-timeout`. | Useful for slow or distant servers. |
+| **Set Test Timeout** | Tune connection checks with `connect_timeout` or `--connect-timeout`. | Useful for slow or distant servers. |
 | **Disable Features** | Flags `--no-url-test`, `--no-sort`, `--no-base64` and `--no-csv` give full control. | Skip slow checks or extra files when not needed. |
 | **Max Ping Filter** | Remove configs with latency above `--max-ping` ms. | Keep only fast servers for gaming or streaming. |
 | **Concurrent Limit / Retries** | Tweak network load with `--concurrent-limit` and `--max-retries`. | Prevent crashes on slow networks or strict hosts. |

--- a/src/massconfigmerger/config.py
+++ b/src/massconfigmerger/config.py
@@ -84,7 +84,6 @@ class Settings(BaseSettings):
     )
     enable_url_testing: bool = True
     enable_sorting: bool = True
-    test_timeout: float = 5.0
     save_every: int = 1000
     stop_after_found: int = 0
     top_n: int = 0

--- a/src/massconfigmerger/vpn_merger.py
+++ b/src/massconfigmerger/vpn_merger.py
@@ -971,8 +971,12 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
                         help="Resume processing from existing raw/base64 file")
     parser.add_argument("--output-dir", type=str, default=CONFIG.output_dir,
                         help="Directory to save output files")
-    parser.add_argument("--test-timeout", type=float, default=CONFIG.connect_timeout,
-                        help="TCP connection test timeout in seconds")
+    parser.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=CONFIG.connect_timeout,
+        help="TCP connect timeout in seconds",
+    )
     parser.add_argument("--no-url-test", action="store_true",
                         help="Disable server reachability testing")
     parser.add_argument("--no-sort", action="store_true",
@@ -1129,7 +1133,7 @@ def main(args: argparse.Namespace | None = None) -> int:
     resolved_output = Path(args.output_dir).expanduser().resolve()
     resolved_output.mkdir(parents=True, exist_ok=True)
     CONFIG.output_dir = str(resolved_output)
-    CONFIG.connect_timeout = max(0.1, args.test_timeout)
+    CONFIG.connect_timeout = max(0.1, args.connect_timeout)
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
     CONFIG.max_retries = max(1, args.max_retries)
     CONFIG.max_ping_ms = args.max_ping if args.max_ping > 0 else None

--- a/src/massconfigmerger/vpn_retester.py
+++ b/src/massconfigmerger/vpn_retester.py
@@ -110,8 +110,12 @@ def build_parser(parser: argparse.ArgumentParser | None = None) -> argparse.Argu
     parser.add_argument("--no-sort", action="store_true", help="Skip sorting by latency")
     parser.add_argument("--concurrent-limit", type=int, default=CONFIG.concurrent_limit,
                         help="Number of concurrent tests")
-    parser.add_argument("--test-timeout", type=float, default=CONFIG.connect_timeout,
-                        help="TCP connection timeout in seconds")
+    parser.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=CONFIG.connect_timeout,
+        help="TCP connect timeout in seconds",
+    )
     parser.add_argument("--max-ping", type=int, default=0,
                         help="Discard configs slower than this ping in ms (0 disables)")
     parser.add_argument(
@@ -143,7 +147,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         sys.exit(1)
 
     CONFIG.concurrent_limit = max(1, args.concurrent_limit)
-    CONFIG.connect_timeout = max(0.1, args.test_timeout)
+    CONFIG.connect_timeout = max(0.1, args.connect_timeout)
     CONFIG.max_ping_ms = args.max_ping if args.max_ping > 0 else None
     if args.include_protocols:
         CONFIG.include_protocols = {p.strip().upper() for p in args.include_protocols.split(',') if p.strip()}


### PR DESCRIPTION
## Summary
- drop the `test_timeout` setting in favor of `connect_timeout`
- rename CLI options to `--connect-timeout`
- update docs and examples for the new name
- mention connect timeout tuning in the FAQ

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878d732e8e48326961f9967d8361f43